### PR TITLE
vagrant: Improve network interfaces support

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -38,6 +38,7 @@ lineinfile
 linuxgce
 machineaccount
 makecache
+NETNAMES
 netns
 noconfirm
 norecursedirs

--- a/src/molecule_plugins/vagrant/modules/vagrant.py
+++ b/src/molecule_plugins/vagrant/modules/vagrant.py
@@ -176,6 +176,7 @@ EXAMPLES = """
 See doc/source/configuration.rst
 """
 
+VAGRANT_VALID_NETNAMES = ["private_network", "public_network", "forwarded_port"]
 VAGRANTFILE_TEMPLATE = """
 {% macro ruby_format(value) %}
   {% if value is boolean %}
@@ -250,7 +251,7 @@ Vagrant.configure('2') do |config|
 
     # Network
     {% for n in instance.networks %}
-    c.vm.network "{{ n.name }}", {{ dict2args(n.options) | trim }}
+    c.vm.network "{{ n.name }}"{% if 'options' in n %}, {{ dict2args(n.options) | trim }}{% endif %}
     {% endfor %}
     {% endif %}
     {% if instance.instance_raw_config_args is not none %}
@@ -618,10 +619,16 @@ class VagrantClient:
         networks = []
         if "interfaces" in instance:
             for iface in instance["interfaces"]:
+                net_name = iface["network_name"]
+                if net_name not in VAGRANT_VALID_NETNAMES:
+                    self._module.fail_json(
+                        msg=f"Invalid network_name value {net_name}.",
+                    )
                 net = {}
-                net["name"] = iface["network_name"]
+                net["name"] = net_name
                 iface.pop("network_name")
-                net["options"] = iface
+                if len(iface) > 0:
+                    net["options"] = iface
                 networks.append(net)
 
         # compat

--- a/src/molecule_plugins/vagrant/modules/vagrant.py
+++ b/src/molecule_plugins/vagrant/modules/vagrant.py
@@ -619,16 +619,19 @@ class VagrantClient:
         networks = []
         if "interfaces" in instance:
             for iface in instance["interfaces"]:
-                net_name = iface["network_name"]
+                net_name = iface.get("network_name")
+                if net_name is None:
+                    self._module.fail_json(
+                        msg="Each interface must have a 'network_name' key.",
+                    )
                 if net_name not in VAGRANT_VALID_NETNAMES:
                     self._module.fail_json(
                         msg=f"Invalid network_name value {net_name}.",
                     )
-                net = {}
-                net["name"] = net_name
-                iface.pop("network_name")
-                if len(iface) > 0:
-                    net["options"] = iface
+                net = {"name": net_name}
+                options = {k: v for k, v in iface.items() if k != "network_name"}
+                if options:
+                    net["options"] = options
                 networks.append(net)
 
         # compat

--- a/test/vagrant-plugin/functional/test_func.py
+++ b/test/vagrant-plugin/functional/test_func.py
@@ -102,6 +102,25 @@ def test_invalid_settings(temp_dir):
     not is_vagrant_supported(),
     reason="vagrant not supported on this machine",
 )
+def test_invalid_network_name(temp_dir):
+    scenario_directory = os.path.join(
+        os.path.dirname(util.abs_path(__file__)),
+        os.path.pardir,
+        "scenarios",
+    )
+
+    with change_dir_to(scenario_directory):
+        cmd = ["molecule", "create", "--scenario-name", "invalid_net"]
+        result = get_app(Path()).run_command(cmd)
+        assert result.returncode == 2
+
+        assert "Invalid network_name value my_network." in result.stdout
+
+
+@pytest.mark.skipif(
+    not is_vagrant_supported(),
+    reason="vagrant not supported on this machine",
+)
 @pytest.mark.parametrize(
     "scenario",
     [

--- a/test/vagrant-plugin/scenarios/molecule/network/molecule.yml
+++ b/test/vagrant-plugin/scenarios/molecule/network/molecule.yml
@@ -15,6 +15,7 @@ platforms:
       - network_name: private_network
         ip: 192.168.56.4
         auto_config: true
+      - network_name: public_network
 provisioner:
   name: ansible
 verifier:

--- a/test/vagrant-plugin/scenarios/molecule/network/verify.yml
+++ b/test/vagrant-plugin/scenarios/molecule/network/verify.yml
@@ -5,7 +5,7 @@
   gather_subset:
     - network
   tasks:
-    - name: Check that there are 3 interfaces
+    - name: Check that there are 4 interfaces
       ansible.builtin.assert:
         that:
-          - "{{ ansible_interfaces | length == 3 }}"
+          - "{{ ansible_interfaces | length == 4 }}"

--- a/test/vagrant/scenarios/molecule/invalid_net/converge.yml
+++ b/test/vagrant/scenarios/molecule/invalid_net/converge.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Sample task # noqa command-instead-of-shell
+      ansible.builtin.shell:
+        cmd: uname
+      changed_when: false

--- a/test/vagrant/scenarios/molecule/invalid_net/molecule.yml
+++ b/test/vagrant/scenarios/molecule/invalid_net/molecule.yml
@@ -1,0 +1,11 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+platforms:
+  - name: instance/foo
+    interfaces:
+      - network_name: my_network
+provisioner:
+  name: ansible


### PR DESCRIPTION
Current code doesn't ensure that the network name is valid. According to current Vagrant documentation, it can only be:
- public_network
- private_network
- forwarded_port

Moreover, the same documentation is saying that public network configuration may be reduced to:

config.vm.network "public_network"

So add needed code to support interfaces without any options.

On the test side:
- modify the network test to check that the generated Vagrantfile is correct when no option is specified
- add a test to ensure invalid network name are caught.

Fixes: #99