### PR TITLE
Fix: Ensure Vagrant default provisioning mode is "once"

### DIFF
--- a/src/molecule_plugins/vagrant/modules/vagrant.py
+++ b/src/molecule_plugins/vagrant/modules/vagrant.py
@@ -690,7 +690,7 @@ def main():
             provider_raw_config_args=dict(type="list", default=None),
             provider_name=dict(type="str", default="virtualbox"),
             default_box=dict(type="str", default=None),
-            provision=dict(type="bool", default=False),
+            provision=dict(type="bool", default=None),
             force_stop=dict(type="bool", default=False),
             cachier=dict(type="str", default="machine"),
             state=dict(type="str", default="up", choices=["up", "destroy", "halt"]),


### PR DESCRIPTION
Considering:
* Default value of `python-vagrant` for `provision` is [`None`](https://github.com/pycontribs/python-vagrant/blob/main/src/vagrant/__init__.py#L316)
* `python-vagrant` documentation states [the boolean is optional](https://github.com/pycontribs/python-vagrant/blob/main/src/vagrant/__init__.py#L328-L329), defaulting to Vagrant default behaviour (which is [to run provisioners once on creation](https://developer.hashicorp.com/vagrant/docs/provisioning/basic_usage#run-once-always-or-never))

The Molecule's Vagrant plugin currently override the default value, defaulting to `False`, and only settable to `True` (`None` is rejected, not being a boolean).
This PR suggests a change so the default value of the Molecule plugin is aligned with `python-vagrant`'s one, and eventually with Vagrant's behaviour.