### PR TITLE
doc: add absent molecule plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ This repository contains the following molecule plugins:
 - azure
 - docker
 - gce
+- containers
+- ec2
+- podman
+- vagrant
 
 Installing `molecule-plugins` does not install dependencies specific to each,
 plugin. To install these you need to install the extras for each plugin, like


### PR DESCRIPTION
Hey, just wanted to let you know that I noticed a few molecule plugins are missing. So, I went ahead and made a pull request to add them. Let me know what you think and if you have any suggestions.