### PR TITLE
install python3 only when ansible_system == Linux

### DIFF
--- a/src/molecule_plugins/vagrant/playbooks/prepare.yml
+++ b/src/molecule_plugins/vagrant/playbooks/prepare.yml
@@ -1,19 +1,12 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: Bootstrap python for Ansible
-      ansible.builtin.raw: |
-        command -v python3 python || (
-        command -v apk >/dev/null && sudo apk add --no-progress --update python3 ||
-        (test -e /usr/bin/dnf && sudo dnf install -y python3) ||
-        (test -e /usr/bin/apt && (apt -y update && apt install -y python3-minimal)) ||
-        (test -e /usr/bin/yum && sudo yum -y -qq install python3) ||
-        (test -e /usr/sbin/pkg && sudo env ASSUME_ALWAYS_YES=yes pkg update && sudo env ASSUME_ALWAYS_YES=yes pkg install python3) ||
-        (test -e /usr/sbin/pkg_add && sudo /usr/sbin/pkg_add -U -I -x python%3.9) ||
-        echo "Warning: Python not bootstrapped due to unknown platform."
-        )
+      ansible.builtin.package:
+        name: python3
+        state: present
       become: true
       changed_when: false
-      when: ansible_connection != 'winrm'
+      when: ansible_system == "Linux"

--- a/src/molecule_plugins/vagrant/playbooks/prepare.yml
+++ b/src/molecule_plugins/vagrant/playbooks/prepare.yml
@@ -4,9 +4,16 @@
   gather_facts: true
   tasks:
     - name: Bootstrap python for Ansible
-      ansible.builtin.package:
-        name: python3
-        state: present
+      ansible.builtin.raw: |
+        command -v python3 python || (
+        command -v apk >/dev/null && sudo apk add --no-progress --update python3 ||
+        (test -e /usr/bin/dnf && sudo dnf install -y python3) ||
+        (test -e /usr/bin/apt && (apt -y update && apt install -y python3-minimal)) ||
+        (test -e /usr/bin/yum && sudo yum -y -qq install python3) ||
+        (test -e /usr/sbin/pkg && sudo env ASSUME_ALWAYS_YES=yes pkg update && sudo env ASSUME_ALWAYS_YES=yes pkg install python3) ||
+        (test -e /usr/sbin/pkg_add && sudo /usr/sbin/pkg_add -U -I -x python%3.9) ||
+        echo "Warning: Python not bootstrapped due to unknown platform."
+        )
       become: true
       changed_when: false
       when: ansible_system == "Linux"

--- a/src/molecule_plugins/vagrant/playbooks/prepare.yml
+++ b/src/molecule_plugins/vagrant/playbooks/prepare.yml
@@ -16,3 +16,4 @@
         )
       become: true
       changed_when: false
+      when: ansible_connection != 'winrm'

--- a/src/molecule_plugins/vagrant/playbooks/prepare.yml
+++ b/src/molecule_plugins/vagrant/playbooks/prepare.yml
@@ -1,8 +1,14 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: true
+  gather_facts: false
   tasks:
+    - name: Gather system info
+      ansible.builtin.raw: uname
+      register: raw_uname
+      changed_when: false
+      failed_when: false
+
     - name: Bootstrap python for Ansible
       ansible.builtin.raw: |
         command -v python3 python || (
@@ -16,4 +22,4 @@
         )
       become: true
       changed_when: false
-      when: ansible_system == "Linux"
+      when: raw_uname.rc == 0 and raw_uname.stdout | trim == "Linux"


### PR DESCRIPTION
This PR:
- install python3 only when `ansible_system == Linux`
- closes #109 