### PR TITLE
fix: Ensure SSH wait polls proper async variable in ec2 create

### DIFF
--- a/src/molecule_plugins/ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/src/molecule_plugins/ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -312,7 +312,7 @@
             index_var: index
             label: "{{ platforms[index].name }}"
           register: ssh_wait
-          until: ssh_wait_async is finished
+          until: ssh_wait is finished
           retries: 300
           delay: 1
 


### PR DESCRIPTION
Removes the warning during EC2 create:

```
[WARNING]: The 'finished' test expects an async task, but a non-async task was tested
```