### PR TITLE
deprecated(azure): replace VM type

### DIFF
--- a/src/molecule_plugins/azure/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/src/molecule_plugins/azure/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -43,7 +43,7 @@
       azure.azcollection.azure_rm_virtualmachine:
         resource_group: "{{ resource_group_name }}"
         name: "{{ item.name }}"
-        vm_size: Standard_A0
+        vm_size: Standard_B1ms
         admin_username: "{{ ssh_user }}"
         public_ip_allocation_method: Dynamic
         ssh_password_enabled: false
@@ -53,7 +53,7 @@
         image:
           offer: CentOS
           publisher: OpenLogic
-          sku: '7.4'
+          sku: '8_5-gen2'
           version: latest
       register: server
       with_items: "{{ molecule_yml.platforms }}"


### PR DESCRIPTION
`Standard_A0` Is gonna get deprecated on august 2024. 
`Standard_B1ms` is the same price (15$), has a burst capability ( good for ansible testing workload ), has 2GB of ram

the `Standard_B1s` has 1GB RAM and half the price but from my experience 1GB is bothersome when installing large packages with yum, maintainer input is appreciated

`Centos 8_5-gen2` looks stable, couldn't find any known bugs or problems with a google search, newer base package make life easier.