### PR TITLE
[PATCH] `driver.provider.name` Overrided by `VAGRANT_DEFAULT_PROVIDER`

### DIFF
--- a/src/molecule_plugins/vagrant/modules/vagrant.py
+++ b/src/molecule_plugins/vagrant/modules/vagrant.py
@@ -338,6 +338,7 @@ stderr:
 class VagrantClient:
     def __init__(self, module) -> None:
         self._module = module
+        self.provider = self._module.params["provider_name"]
         self.provision = self._module.params["provision"]
         self.cachier = self._module.params["cachier"]
 
@@ -425,9 +426,10 @@ class VagrantClient:
         changed = False
         if self._running() != len(self.instances):
             changed = True
+            provider = self.provider
             provision = self.provision
             with contextlib.suppress(Exception):
-                self._vagrant.up(provision=provision)
+                self._vagrant.up(provider=provider, provision=provision)
 
         # NOTE(retr0h): Ansible wants only one module return `fail_json`
         # or `exit_json`.


### PR DESCRIPTION
In case environment variable `VAGRANT_DEFAULT_PROVIDER` is defined (see <https://www.vagrantup.com/docs/other/environmental-variables#vagrant_default_provider>), our `driver.provider.name` will have no effect and always start with above default provider as specifiied.

With python-vagrant `up()` (see
<https://github.com/pycontribs/python-vagrant/blob/main/src/vagrant/__init__.py#L310-L318>) we could specify the target provider with `provider` option, where our current wrapper only provide the `provision` option.

See https://github.com/ansible-community/molecule-vagrant/pull/174