### PR TITLE
enhancement: Including files in source distributions with MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include LICENSE
+include README.md
+
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]
+
+recursive-include src/molecule_plugins/*/cookiecutter **/*
+recursive-include src/molecule_plugins/*/modules **/*
+recursive-include src/molecule_plugins/*/playbooks **/*


### PR DESCRIPTION
When packaging as .deb/.rpm with setuptools (sometime without setuptools_scm), some required template files are excluded from the final packaging result, unless specify them within `MANIFEST.in`.

See https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html
See https://packaging.python.org/en/latest/guides/using-manifest-in