### PR TITLE
Enforce pkcs1 for ec2 keys

### DIFF
--- a/src/molecule_plugins/ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/src/molecule_plugins/ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -128,6 +128,8 @@
         type: rsa
         size: 2048
         regenerate: never
+        backend: cryptography
+        private_key_format: pkcs1
       loop: "{{ platforms }}"
       loop_control:
         label: "{{ item.name }}"


### PR DESCRIPTION
The driver code expects an pkcs1 key for fetching the windows password. Make sure we generate the correct key type.

Current code fails with:

```
Traceback (most recent call last):
  File "/usr/local/bin/molecule", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/molecule/command/test.py", line 113, in test
    base.execute_cmdline_scenarios(scenario_name, args, command_args, ansible_args)
  File "/usr/local/lib/python3.11/site-packages/molecule/command/base.py", line 119, in execute_cmdline_scenarios
    execute_scenario(scenario)
  File "/usr/local/lib/python3.11/site-packages/molecule/command/base.py", line 162, in execute_scenario
    execute_subcommand(scenario.config, action)
  File "/usr/local/lib/python3.11/site-packages/molecule/command/base.py", line 152, in execute_subcommand
    return command(config).execute(args)
           ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/molecule/command/base.py", line 52, in __init__
    self._setup()
  File "/usr/local/lib/python3.11/site-packages/molecule/command/base.py", line 71, in _setup
    self._config.provisioner.manage_inventory()
  File "/usr/local/lib/python3.11/site-packages/molecule/provisioner/ansible.py", line 849, in manage_inventory
    self._write_inventory()
  File "/usr/local/lib/python3.11/site-packages/molecule/provisioner/ansible.py", line 895, in _write_inventory
    self._verify_inventory()
  File "/usr/local/lib/python3.11/site-packages/molecule/provisioner/ansible.py", line 949, in _verify_inventory
    if not self.inventory:
           ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/molecule/provisioner/ansible.py", line 666, in inventory
    connection_options = self.connection_options(instance_name)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/molecule/provisioner/ansible.py", line 730, in connection_options
    d = self._config.driver.ansible_connection_options(instance_name)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/molecule_plugins/ec2/driver.py", line 243, in ansible_connection_options
    conn_opts["ansible_password"] = self._get_windows_instance_pass(
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/molecule_plugins/ec2/driver.py", line 273, in _get_windows_instance_pass
    key = load_pem_private_key(f.read(), None, default_backend())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/cryptography/hazmat/primitives/serialization/base.py", line 24, in load_pem_private_key
    return ossl.load_pem_private_key(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 957, in load_pem_private_key
    return self._load_key(
           ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 1152, in _load_key
    self._handle_key_loading_error()
  File "/usr/local/lib/python3.11/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 1207, in _handle_key_loading_error
    raise ValueError(
ValueError: ('Could not deserialize key data. The data may be in an incorrect format, it may be encrypted with an unsupported algorithm, or it may be an unsupported key type (e.g. EC curves with explicit parameters).', [<OpenSSLError(code=503841036, lib=60, reason=524556, reason_text=unsupported)>])
```