### PR TITLE
Allow for setting EC2 instance profile

### DIFF
--- a/doc/ec2/platforms.rst
+++ b/doc/ec2/platforms.rst
@@ -29,6 +29,7 @@ cloud_config                Dictionary suitable for instance user_data
 connection_options          See Connection Options section
 image                       AMI to use, see Image Selection section
 image_filters               Filters to select AMI, see Image Selection section
+iam_instance_profile        The IAM instance profile for the instance
 image_name                  Name of AMI, see Image Selection section
 image_owner                 Owner of AMI, see Image Selection section
 instance_type               AWS EC2 instance type, defaults to t3a.medium

--- a/src/molecule_plugins/ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/src/molecule_plugins/ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -186,6 +186,7 @@
     - name: Create ephemeral security groups (if needed)
       ec2_group:
         profile: "{{ item.aws_profile | default(omit) }}"
+        iam_instance_profile : "{{ item.iam_instance_profile | default(omit) }}"
         region: "{{ item.region | default(omit) }}"
         vpc_id: "{{ item.vpc_id or vpc_subnet.vpc_id }}"
         name: "{{ item.security_group_name }}"

--- a/src/molecule_plugins/ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/src/molecule_plugins/ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -186,7 +186,7 @@
     - name: Create ephemeral security groups (if needed)
       ec2_group:
         profile: "{{ item.aws_profile | default(omit) }}"
-        iam_instance_profile : "{{ item.iam_instance_profile | default(omit) }}"
+        iam_instance_profile: "{{ item.iam_instance_profile | default(omit) }}"
         region: "{{ item.region | default(omit) }}"
         vpc_id: "{{ item.vpc_id or vpc_subnet.vpc_id }}"
         name: "{{ item.security_group_name }}"


### PR DESCRIPTION
This is a small change, but I think it would be useful for people to be able to set an instance profile if the EC2 instance needs access to other AWS resources, like S3 buckets.