### PR TITLE
Prevent empty destroy from deleting other EC2 instances

### DIFF
--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -16,3 +16,5 @@ test/roles/containersplugin/molecule/default/destroy.yml yaml[octal-values]
 test/roles/containersplugin/molecule/default/create.yml yaml[octal-values]
 test/roles/azureplugin/molecule/default/create.yml yaml[octal-values]
 test/roles/azureplugin/molecule/default/destroy.yml yaml[octal-values]
+
+test/roles/ec2plugin/molecule/default/destroy.yml risky-file-permissions

--- a/src/molecule_plugins/ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/src/molecule_plugins/ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -81,61 +81,62 @@
         index_var: index
         label: "{{ platform.name }}"
 
-    - block:
-      - name: Destroy ephemeral EC2 instances
-        ec2_instance:
-          profile: "{{ item.aws_profile | default(omit) }}"
-          region: "{{ item.region | default(omit) }}"
-          instance_ids: "{{ instance_config | map(attribute='instance_ids') | flatten }}"
-          state: absent
-        loop: "{{ platforms }}"
-        loop_control:
-          label: "{{ item.name }}"
-        register: ec2_instances_async
-        async: 7200
-        poll: 0
-
-      - name: Wait for instance destruction to complete
-        async_status:
-          jid: "{{ item.ansible_job_id }}"
-        loop: "{{ ec2_instances_async.results }}"
-        loop_control:
-          index_var: index
-          label: "{{ platforms[index].name }}"
-        register: ec2_instances
-        until: ec2_instances is finished
-        retries: 300
-
-      - name: Write Molecule instance configs
-        copy:
-          dest: "{{ molecule_instance_config }}"
-          content: "{{ {} | to_yaml }}"
-
-      - name: Destroy ephemeral security groups (if needed)
-        ec2_group:
-          profile: "{{ item.aws_profile | default(omit) }}"
-          region: "{{ item.region | default(omit) }}"
-          vpc_id: "{{ item.vpc_id or vpc_subnet.vpc_id }}"
-          name: "{{ item.security_group_name }}"
-          state: absent
-        vars:
-          vpc_subnet: "{{ subnet_info.results[index].subnets[0] }}"
-        loop: "{{ platforms }}"
-        loop_control:
-          index_var: index
-          label: "{{ item.name }}"
-        when: item.security_groups | length == 0
-
-      - name: Destroy ephemeral keys (if needed)
-        ec2_key:
-          profile: "{{ item.aws_profile | default(omit) }}"
-          region: "{{ item.region | default(omit) }}"
-          name: "{{ item.key_name }}"
-          state: absent
-        loop: "{{ platforms }}"
-        loop_control:
-          index_var: index
-          label: "{{ item.name }}"
-        when: item.key_inject_method == "ec2"
+    - name: Destroy resources
       when: instance_config | length != 0
+      block:
+        - name: Destroy ephemeral EC2 instances
+          amazon.aws.ec2_instance:
+            profile: "{{ item.aws_profile | default(omit) }}"
+            region: "{{ item.region | default(omit) }}"
+            instance_ids: "{{ instance_config | map(attribute='instance_ids') | flatten }}"
+            state: absent
+          loop: "{{ platforms }}"
+          loop_control:
+            label: "{{ item.name }}"
+          register: ec2_instances_async
+          async: 7200
+          poll: 0
+
+        - name: Wait for instance destruction to complete
+          ansible.builtin.async_status:
+            jid: "{{ item.ansible_job_id }}"
+          loop: "{{ ec2_instances_async.results }}"
+          loop_control:
+            index_var: index
+            label: "{{ platforms[index].name }}"
+          register: ec2_instances
+          until: ec2_instances is finished
+          retries: 300
+
+        - name: Write Molecule instance configs
+          ansible.builtin.copy:
+            dest: "{{ molecule_instance_config }}"
+            content: "{{ {} | to_yaml }}"
+
+        - name: Destroy ephemeral security groups (if needed)
+          amazon.aws.ec2_security_group:
+            profile: "{{ item.aws_profile | default(omit) }}"
+            region: "{{ item.region | default(omit) }}"
+            vpc_id: "{{ item.vpc_id or vpc_subnet.vpc_id }}"
+            name: "{{ item.security_group_name }}"
+            state: absent
+          vars:
+            vpc_subnet: "{{ subnet_info.results[index].subnets[0] }}"
+          loop: "{{ platforms }}"
+          loop_control:
+            index_var: index
+            label: "{{ item.name }}"
+          when: item.security_groups | length == 0
+
+        - name: Destroy ephemeral keys (if needed)
+          amazon.aws.ec2_key:
+            profile: "{{ item.aws_profile | default(omit) }}"
+            region: "{{ item.region | default(omit) }}"
+            name: "{{ item.key_name }}"
+            state: absent
+          loop: "{{ platforms }}"
+          loop_control:
+            index_var: index
+            label: "{{ item.name }}"
+          when: item.key_inject_method == "ec2"
 {%- endraw %}

--- a/src/molecule_plugins/ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/src/molecule_plugins/ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -81,60 +81,61 @@
         index_var: index
         label: "{{ platform.name }}"
 
-    - name: Destroy ephemeral EC2 instances
-      amazon.aws.ec2_instance:
-        profile: "{{ item.aws_profile | default(omit) }}"
-        region: "{{ item.region | default(omit) }}"
-        instance_ids: "{{ instance_config | map(attribute='instance_ids') | flatten }}"
-        state: absent
-      loop: "{{ platforms }}"
-      loop_control:
-        label: "{{ item.name }}"
-      register: ec2_instances_async
-      async: 7200
-      poll: 0
+    - block:
+      - name: Destroy ephemeral EC2 instances
+        ec2_instance:
+          profile: "{{ item.aws_profile | default(omit) }}"
+          region: "{{ item.region | default(omit) }}"
+          instance_ids: "{{ instance_config | map(attribute='instance_ids') | flatten }}"
+          state: absent
+        loop: "{{ platforms }}"
+        loop_control:
+          label: "{{ item.name }}"
+        register: ec2_instances_async
+        async: 7200
+        poll: 0
 
-    - name: Wait for instance destruction to complete
-      ansible.builtin.async_status:
-        jid: "{{ item.ansible_job_id }}"
-      loop: "{{ ec2_instances_async.results }}"
-      loop_control:
-        index_var: index
-        label: "{{ platforms[index].name }}"
-      register: ec2_instances
-      until: ec2_instances is finished
-      retries: 300
+      - name: Wait for instance destruction to complete
+        async_status:
+          jid: "{{ item.ansible_job_id }}"
+        loop: "{{ ec2_instances_async.results }}"
+        loop_control:
+          index_var: index
+          label: "{{ platforms[index].name }}"
+        register: ec2_instances
+        until: ec2_instances is finished
+        retries: 300
 
-    - name: Write Molecule instance configs
-      ansible.builtin.copy:
-        dest: "{{ molecule_instance_config }}"
-        content: "{{ {} | to_yaml }}"
-        mode: "0644"
+      - name: Write Molecule instance configs
+        copy:
+          dest: "{{ molecule_instance_config }}"
+          content: "{{ {} | to_yaml }}"
 
-    - name: Destroy ephemeral security groups (if needed)
-      amazon.aws.ec2_security_group:
-        profile: "{{ item.aws_profile | default(omit) }}"
-        region: "{{ item.region | default(omit) }}"
-        vpc_id: "{{ item.vpc_id or vpc_subnet.vpc_id }}"
-        name: "{{ item.security_group_name }}"
-        state: absent
-      vars:
-        vpc_subnet: "{{ subnet_info.results[index].subnets[0] }}"
-      loop: "{{ platforms }}"
-      loop_control:
-        index_var: index
-        label: "{{ item.name }}"
-      when: item.security_groups | length == 0
+      - name: Destroy ephemeral security groups (if needed)
+        ec2_group:
+          profile: "{{ item.aws_profile | default(omit) }}"
+          region: "{{ item.region | default(omit) }}"
+          vpc_id: "{{ item.vpc_id or vpc_subnet.vpc_id }}"
+          name: "{{ item.security_group_name }}"
+          state: absent
+        vars:
+          vpc_subnet: "{{ subnet_info.results[index].subnets[0] }}"
+        loop: "{{ platforms }}"
+        loop_control:
+          index_var: index
+          label: "{{ item.name }}"
+        when: item.security_groups | length == 0
 
-    - name: Destroy ephemeral keys (if needed)
-      amazon.aws.ec2_key:
-        profile: "{{ item.aws_profile | default(omit) }}"
-        region: "{{ item.region | default(omit) }}"
-        name: "{{ item.key_name }}"
-        state: absent
-      loop: "{{ platforms }}"
-      loop_control:
-        index_var: index
-        label: "{{ item.name }}"
-      when: item.key_inject_method == "ec2"
+      - name: Destroy ephemeral keys (if needed)
+        ec2_key:
+          profile: "{{ item.aws_profile | default(omit) }}"
+          region: "{{ item.region | default(omit) }}"
+          name: "{{ item.key_name }}"
+          state: absent
+        loop: "{{ platforms }}"
+        loop_control:
+          index_var: index
+          label: "{{ item.name }}"
+        when: item.key_inject_method == "ec2"
+      when: instance_config | length != 0
 {%- endraw %}


### PR DESCRIPTION
This PR seeks to fix the issue described in https://github.com/ansible-community/molecule-plugins/issues/136 and https://github.com/ansible-community/molecule-plugins/issues/121.

Currently, when using the EC2 Molecule plugin, issuing a `molecule test` command will cause _all_ other EC2 instances in the subnet to be deleted. This is because the "destroy" phase gets run before the "create" phase, plus the fact that when the `amazon.aws.ec2_instance` Ansible module is called with no `instance_id` attribute (as is the case or a fresh `molecule test` command), the operation applies to all EC2 instance.

I've added in a block that checks that the `instance_config` is _not empty_ before attempting to destroy EC2 instance.