### PR TITLE
podman: change ansible_async_dir only when $HOME is redefined

### DIFF
--- a/src/molecule_plugins/podman/playbooks/create.yml
+++ b/src/molecule_plugins/podman/playbooks/create.yml
@@ -17,10 +17,23 @@
       ansible.builtin.set_fact:
         podman_cmd: "{{ _podman_path.stdout }}"
 
+    - name: Get passwd entries for USER env
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ lookup('env', 'USER') }}"
+
+    - name: Get shell async_dir
+      ansible.builtin.set_fact:
+        _shell_async_dir: >-
+          {{ lookup('ansible.builtin.config', 'async_dir', plugin_type='shell', plugin_name='sh')
+             | regex_replace('^~', ansible_facts.getent_passwd[lookup('env', 'USER')][4]) }}
+
     - name: Set async_dir for HOME env
       ansible.builtin.set_fact:
-        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
-      when: (lookup('env', 'HOME'))
+        ansible_async_dir: >-
+          {{ _shell_async_dir
+             | regex_replace('^' + ansible_facts.getent_passwd[lookup('env', 'USER')][4], lookup('env', 'HOME')) }}
+      when: lookup('env', 'HOME') != ansible_facts.getent_passwd[lookup('env', 'USER')][4]
 
     - name: Log into a container registry
       ansible.builtin.command: >

--- a/src/molecule_plugins/podman/playbooks/destroy.yml
+++ b/src/molecule_plugins/podman/playbooks/destroy.yml
@@ -8,10 +8,23 @@
   vars:
     podman_exec: "{{ lookup('env','MOLECULE_PODMAN_EXECUTABLE')|default('podman',true) }}"
   tasks:
+    - name: Get passwd entries for USER env
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ lookup('env', 'USER') }}"
+
+    - name: Get shell async_dir
+      ansible.builtin.set_fact:
+        _shell_async_dir: >-
+          {{ lookup('ansible.builtin.config', 'async_dir', plugin_type='shell', plugin_name='sh')
+             | regex_replace('^~', ansible_facts.getent_passwd[lookup('env', 'USER')][4]) }}
+
     - name: Set async_dir for HOME env
       ansible.builtin.set_fact:
-        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
-      when: (lookup('env', 'HOME'))
+        ansible_async_dir: >-
+          {{ _shell_async_dir
+             | regex_replace('^' + ansible_facts.getent_passwd[lookup('env', 'USER')][4], lookup('env', 'HOME')) }}
+      when: lookup('env', 'HOME') != ansible_facts.getent_passwd[lookup('env', 'USER')][4]
 
     - name: Destroy molecule instance(s)
       ansible.builtin.shell: "{{ podman_exec }} container exists {{ item.name }} && {{ podman_exec }} rm -f {{ item.name }} || true"

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,7 @@ passenv =
     SSL_CERT_FILE
     TOXENV
     TWINE_*
+    USER
 allowlist_externals =
     bash
     twine


### PR DESCRIPTION
fixes #73 

This PR tries to avoid the hardcoding of `ansible_async_dir` introduced in [molecule-podman PR #139](https://github.com/ansible-community/molecule-podman/pull/139) by using `ansible.builtin.getent` to get the `$USER` passwd data and by using `ansible.builtin.config` to get `async_dir` from the shell configuration. `ansible_async_dir` will be set only if the two home paths are different and the value will pick up the changes set from the rest of the controller set-up.

`tox.ini` is also updated to allow `lookup('env', 'USER')` to work in the CI.