### PR TITLE
podman: remove ansible_async_dir setting logic

### DIFF
--- a/src/molecule_plugins/podman/playbooks/create.yml
+++ b/src/molecule_plugins/podman/playbooks/create.yml
@@ -17,24 +17,6 @@
       ansible.builtin.set_fact:
         podman_cmd: "{{ _podman_path.stdout }}"
 
-    - name: Get passwd entries for USER env
-      ansible.builtin.getent:
-        database: passwd
-        key: "{{ lookup('env', 'USER') }}"
-
-    - name: Get shell async_dir
-      ansible.builtin.set_fact:
-        _shell_async_dir: >-
-          {{ lookup('ansible.builtin.config', 'async_dir', plugin_type='shell', plugin_name='sh')
-             | regex_replace('^~', ansible_facts.getent_passwd[lookup('env', 'USER')][4]) }}
-
-    - name: Set async_dir for HOME env
-      ansible.builtin.set_fact:
-        ansible_async_dir: >-
-          {{ _shell_async_dir
-             | regex_replace('^' + ansible_facts.getent_passwd[lookup('env', 'USER')][4], lookup('env', 'HOME')) }}
-      when: lookup('env', 'HOME') != ansible_facts.getent_passwd[lookup('env', 'USER')][4]
-
     - name: Log into a container registry
       ansible.builtin.command: >
         {{ podman_cmd }} login

--- a/src/molecule_plugins/podman/playbooks/destroy.yml
+++ b/src/molecule_plugins/podman/playbooks/destroy.yml
@@ -8,24 +8,6 @@
   vars:
     podman_exec: "{{ lookup('env','MOLECULE_PODMAN_EXECUTABLE')|default('podman',true) }}"
   tasks:
-    - name: Get passwd entries for USER env
-      ansible.builtin.getent:
-        database: passwd
-        key: "{{ lookup('env', 'USER') }}"
-
-    - name: Get shell async_dir
-      ansible.builtin.set_fact:
-        _shell_async_dir: >-
-          {{ lookup('ansible.builtin.config', 'async_dir', plugin_type='shell', plugin_name='sh')
-             | regex_replace('^~', ansible_facts.getent_passwd[lookup('env', 'USER')][4]) }}
-
-    - name: Set async_dir for HOME env
-      ansible.builtin.set_fact:
-        ansible_async_dir: >-
-          {{ _shell_async_dir
-             | regex_replace('^' + ansible_facts.getent_passwd[lookup('env', 'USER')][4], lookup('env', 'HOME')) }}
-      when: lookup('env', 'HOME') != ansible_facts.getent_passwd[lookup('env', 'USER')][4]
-
     - name: Destroy molecule instance(s)
       ansible.builtin.shell: "{{ podman_exec }} container exists {{ item.name }} && {{ podman_exec }} rm -f {{ item.name }} || true"
       register: server

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,6 @@ passenv =
     SSL_CERT_FILE
     TOXENV
     TWINE_*
-    USER
 allowlist_externals =
     bash
     twine


### PR DESCRIPTION
fixes #181 

https://github.com/ansible-community/molecule-plugins/commit/b5509a19465ba39cfedff0e6450524620a2d6d2f uses `$USER` to get the home for the current user, but if the controller does not run `login(1)`, like in containers, the variable is not set. This PR uses `whoami` to get the current user.

**EDIT** Since the `ansible_async_dir` setting logic is not needed anymore (see https://github.com/ansible-community/molecule-plugins/pull/182#issuecomment-1807426732) this PR now removes it in `create.yml` and `destroy.yml`.