### PR TITLE
Handle Docker errors correctly

### DIFF
--- a/src/molecule_plugins/docker/driver.py
+++ b/src/molecule_plugins/docker/driver.py
@@ -239,7 +239,6 @@ class Docker(Driver):
         log.info("Sanity checks: '%s'", self._name)
         try:
             import docker
-            import requests
 
             docker_client = docker.from_env()
             docker_client.ping()

--- a/src/molecule_plugins/docker/driver.py
+++ b/src/molecule_plugins/docker/driver.py
@@ -243,7 +243,7 @@ class Docker(Driver):
 
             docker_client = docker.from_env()
             docker_client.ping()
-        except requests.exceptions.ConnectionError:
+        except docker.errors.DockerException:
             msg = (
                 "Unable to contact the Docker daemon. "
                 "Please refer to https://docs.docker.com/config/daemon/ "


### PR DESCRIPTION
docker intercepts errors from requests and returns its own errors, so we actually need to expect a docker error here