### PR TITLE
pass vpc_subnet_id explicitly to avoid amazon.aws error

### DIFF
--- a/src/molecule_plugins/ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/src/molecule_plugins/ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -89,6 +89,7 @@
             profile: "{{ item.aws_profile | default(omit) }}"
             region: "{{ item.region | default(omit) }}"
             instance_ids: "{{ instance_config | map(attribute='instance_ids') | flatten }}"
+            vpc_subnet_id: "{{ item.vpc_subnet_id }}"
             state: absent
           loop: "{{ platforms }}"
           loop_control:


### PR DESCRIPTION
The upstream code there can call  their get_default_vpc(), which will fail if our users do not have one in their AWS account.

It is common practice to remove it and build a more restricted one - causing errors for users that do so.

ref #46 