### PR TITLE
Fix lint execution on osx and ignore generate roles files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 src/molecule_plugins/_version.py
+
+# Ignore generated files
+test/roles

--- a/tools/generate-templates.sh
+++ b/tools/generate-templates.sh
@@ -19,7 +19,7 @@ for DRIVER_NAME in "${DRIVER_NAMES[@]}"; do
 	-e 's!company:.*!company: ansible-community!g' \
 	-e 's!min_ansible_version:.*!min_ansible_version: "2.1"!g' \
 	-e 's!license:.*!license: MIT!g' \
-	-i meta/main.yml
+	-i.backup meta/main.yml
   # Not sure if the issue is in molecule or ansible-lint or pre-commit ansible-lint hook
   # As a workaround, kill the offending files.
   rm -rf tests


### PR DESCRIPTION
This fix avoids the following error on OSX when executing tox lint `sed: -i or -i may not be used with stdin`