### PR TITLE
Remove dependency to molecule.test

### DIFF
--- a/test/azure/functional/conftest.py
+++ b/test/azure/functional/conftest.py
@@ -20,4 +20,4 @@
 #  DEALINGS IN THE SOFTWARE.
 
 
-from molecule.test.conftest import *  # noqa
+from conftest import *  # noqa

--- a/test/azure/functional/test_azure.py
+++ b/test/azure/functional/test_azure.py
@@ -23,8 +23,8 @@ import os
 
 import pytest
 
+from conftest import change_dir_to
 from molecule import logger
-from molecule.test.conftest import change_dir_to
 from molecule.util import run_command
 
 LOG = logger.get_logger(__name__)

--- a/test/containers/functional/conftest.py
+++ b/test/containers/functional/conftest.py
@@ -20,4 +20,4 @@
 #  DEALINGS IN THE SOFTWARE.
 """PyTest Config."""
 
-from molecule.test.conftest import *  # noqa pylint: disable=wildcard-import,unused-wildcard-import
+from conftest import *  # noqa pylint: disable=wildcard-import,unused-wildcard-import

--- a/test/containers/functional/test_containers.py
+++ b/test/containers/functional/test_containers.py
@@ -21,8 +21,8 @@
 """Functional Tests."""
 import os
 
+from conftest import change_dir_to, molecule_directory
 from molecule import logger
-from molecule.test.conftest import change_dir_to, molecule_directory
 from molecule.util import run_command
 
 LOG = logger.get_logger(__name__)

--- a/test/docker/conftest.py
+++ b/test/docker/conftest.py
@@ -1,7 +1,7 @@
 """Pytest Fixtures."""
-import pytest
+from conftest import random_string, temp_dir  # noqa
 
-from molecule.test.conftest import random_string, temp_dir  # noqa
+import pytest
 
 
 @pytest.fixture()

--- a/test/docker/test_func.py
+++ b/test/docker/test_func.py
@@ -6,8 +6,8 @@ import subprocess
 
 import pytest
 
+from conftest import change_dir_to
 from molecule import logger
-from molecule.test.conftest import change_dir_to
 from molecule.util import run_command
 
 LOG = logger.get_logger(__name__)

--- a/test/ec2/functional/conftest.py
+++ b/test/ec2/functional/conftest.py
@@ -20,4 +20,4 @@
 #  DEALINGS IN THE SOFTWARE.
 
 
-from molecule.test.conftest import *  # noqa
+from conftest import *  # noqa

--- a/test/ec2/functional/test_ec2.py
+++ b/test/ec2/functional/test_ec2.py
@@ -23,9 +23,8 @@ import os
 
 import pytest
 
+from conftest import change_dir_to, metadata_lint_update
 from molecule import logger
-from molecule.test.b_functional.conftest import metadata_lint_update
-from molecule.test.conftest import change_dir_to
 from molecule.util import run_command
 
 LOG = logger.get_logger(__name__)

--- a/test/gce/functional/conftest.py
+++ b/test/gce/functional/conftest.py
@@ -20,4 +20,4 @@
 #  DEALINGS IN THE SOFTWARE.
 
 
-from molecule.test.conftest import *  # noqa
+from conftest import *  # noqa

--- a/test/gce/functional/test_func.py
+++ b/test/gce/functional/test_func.py
@@ -23,9 +23,8 @@ import os
 
 import pytest
 
+from conftest import change_dir_to, metadata_lint_update
 from molecule import logger
-from molecule.test.b_functional.conftest import metadata_lint_update
-from molecule.test.conftest import change_dir_to
 from molecule.util import run_command
 
 LOG = logger.get_logger(__name__)

--- a/test/gce/test_driver.py
+++ b/test/gce/test_driver.py
@@ -2,6 +2,5 @@ from molecule import api
 
 
 def test_gce_driver_is_detected():
-    driver_name = __name__.split(".")[0].split("_")[-1]
     drivers = [str(d) for d in api.drivers()]
-    assert driver_name in drivers
+    assert "gce" in drivers

--- a/test/podman/test_func.py
+++ b/test/podman/test_func.py
@@ -3,8 +3,8 @@ import os
 import pathlib
 import subprocess
 
+from conftest import change_dir_to
 from molecule import logger
-from molecule.test.conftest import change_dir_to
 from molecule.util import run_command
 from molecule_plugins.podman import __file__ as module_file
 

--- a/test/vagrant/functional/conftest.py
+++ b/test/vagrant/functional/conftest.py
@@ -20,4 +20,4 @@
 #  DEALINGS IN THE SOFTWARE.
 
 
-from molecule.test.conftest import *  # noqa
+from conftest import *  # noqa

--- a/test/vagrant/functional/test_func.py
+++ b/test/vagrant/functional/test_func.py
@@ -26,9 +26,9 @@ import shutil
 import pytest
 
 import vagrant
+from conftest import change_dir_to
 from molecule import logger, util
 from molecule.scenario import ephemeral_directory
-from molecule.test.conftest import change_dir_to
 from molecule.util import run_command
 
 LOG = logger.get_logger(__name__)


### PR DESCRIPTION
With the move of the molecule tests outside the src it is necessary to vendor the dep fixtures here.

Related: https://github.com/ansible/molecule/pull/4070