### PR TITLE
Support the shm_size docker configuration option

### DIFF
--- a/src/molecule_plugins/docker/driver.py
+++ b/src/molecule_plugins/docker/driver.py
@@ -73,6 +73,7 @@ class Docker(Driver):
             security_opts:
               - seccomp=unconfined
             cgroupns_mode: host|private
+            shm_size: 64M
             devices:
               - /dev/fuse:/dev/fuse:rwm
             volumes:

--- a/src/molecule_plugins/docker/playbooks/create.yml
+++ b/src/molecule_plugins/docker/playbooks/create.yml
@@ -180,6 +180,7 @@
         stop_signal: "{{ item.stop_signal | default(omit) }}"
         kill_signal: "{{ item.kill_signal | default(omit) }}"
         cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
+        shm_size: "{{ item.shm_size | default(omit) }}"
         platform: "{{ item.platform | default(omit) }}"
         comparisons:
           platform: ignore


### PR DESCRIPTION
Add support to configuring docker shm_size in molecule platform configuration. This is already available in the docker_container_module. I believe this solves #215.