### PR TITLE
GCE - Fixed calling windows_auth.py for application auth_kind

### DIFF
--- a/src/molecule_plugins/gce/playbooks/tasks/create_windows_instance.yml
+++ b/src/molecule_plugins/gce/playbooks/tasks/create_windows_instance.yml
@@ -51,6 +51,15 @@
     delay: 10
   loop: "{{ server.results }}"
 
+- name: Set env vars for auth script
+  ansible.builtin.set_fact:
+    script_env_vars:
+      GOOGLE_APPLICATION_CREDENTIALS: "{{ service_account_file }}"
+  vars:
+    auth_kind: "{{ molecule_yml.driver.auth_kind | default(lookup('env', 'GCP_AUTH_KIND')) }}"
+    service_account_file: "{{ molecule_yml.driver.service_account_file | default(lookup('env', 'GCP_SERVICE_ACCOUNT_FILE'), true) }}"
+  when: auth_kind == 'serviceaccount'
+
 - name: Prepare Windows User
   ansible.builtin.script: >
     ./files/windows_auth.py
@@ -60,8 +69,7 @@
     --username molecule_usr
   args:
     executable: python3
-  environment:
-    GOOGLE_APPLICATION_CREDENTIALS: "{{ molecule_yml.driver.service_account_file | default(lookup('env', 'GCP_SERVICE_ACCOUNT_FILE'), true) }}"
+  environment: "{{ script_env_vars | default({}) }}"
   loop: "{{ molecule_yml.platforms }}"
   changed_when:
     - password.rc == 0


### PR DESCRIPTION
fixes https://github.com/ansible-community/molecule-plugins/issues/212

This change makes it so GOOGLE_APPLICATION_CREDENTIALS env variable is only set when using `auth_kind = 'serviceaccount' ` instead of all the time.