### PR TITLE
Add an option to disable/enable floating IPs

### DIFF
--- a/doc/openstack/platforms.rst
+++ b/doc/openstack/platforms.rst
@@ -16,7 +16,8 @@ Platform Arguments
 description                     Set description for instance, \
                                 default = 'Molecule test instance'
 flavor                          Set flavor for instance
-floating_ip                     Ensure instance has a public floating IP, default = true
+floating_ip                     Ensure instance has a public floating IP, \
+                                default = true
 image                           Set instance image
 network                         Mapping of network settings (optional)
 network.name                    Name of network

--- a/doc/openstack/platforms.rst
+++ b/doc/openstack/platforms.rst
@@ -16,6 +16,7 @@ Platform Arguments
 description                     Set description for instance, \
                                 default = 'Molecule test instance'
 flavor                          Set flavor for instance
+floating_ip                     Ensure instance has a public floating IP, default = true
 image                           Set instance image
 network                         Mapping of network settings (optional)
 network.name                    Name of network

--- a/src/molecule_plugins/openstack/playbooks/create.yml
+++ b/src/molecule_plugins/openstack/playbooks/create.yml
@@ -105,6 +105,7 @@
         boot_from_volume: "{{ true if item.volume is defined and item.volume.size else false }}"
         terminate_volume: "{{ true if item.volume is defined and item.volume.size else false }}"
         volume_size: "{{ item.volume.size if item.volume is defined and item.volume.size else omit }}"
+        auto_floating_ip: "{{ item.floating_ip | default(true) }}"
         network: >-
           {{
             'molecule-test-' + item.network.name + '-' + uuid


### PR DESCRIPTION
When the OpenStack driver is used, instances get always a public floating IP address. This floating IP is most of the time a public IPv4 address. Public IPv4 addresses are rare and can be very expensive - depending on the OpenStack provider.

This PR allows to disable floating IPs. The default is not changed, so existing deployments don't need an update.

These floating IPs are not required, if IPv6 is available or if a jumphost is already in place, which can be used for the connection to the internal IPs of a VM.

If the option `auto_floating_ip` is not explicit added, it's implicit added with `true` as default value: https://docs.ansible.com/ansible/latest/collections/openstack/cloud/server_module.html#parameter-auto_ip