### PR TITLE
OpenStack - Improve connection check after instance creation

### DIFF
--- a/src/molecule_plugins/openstack/playbooks/create.yml
+++ b/src/molecule_plugins/openstack/playbooks/create.yml
@@ -166,11 +166,3 @@
             content: "{{ instance_conf }}"
             dest: "{{ molecule_instance_config }}"
             mode: "0600"
-
-        - name: Wait for SSH
-          ansible.builtin.wait_for:
-            port: 22
-            host: "{{ item.address }}"
-            search_regex: SSH
-            delay: 10
-          loop: "{{ lookup('file', molecule_instance_config) | from_yaml }}"

--- a/src/molecule_plugins/openstack/playbooks/prepare.yml
+++ b/src/molecule_plugins/openstack/playbooks/prepare.yml
@@ -3,6 +3,11 @@
   hosts: all
   gather_facts: false
   tasks:
+    - name: Wait for SSH
+      ansible.builtin.wait_for_connection:
+        delay: 10
+        timeout: 180
+
     - name: Gather system info
       ansible.builtin.raw: uname
       register: raw_uname


### PR DESCRIPTION
The `Wait for SSH` task in the `create.yml` playbook makes some assumptions:

* ansible host is always directly accessible from the control node
* port 22 is always used for connection

Both of them are not always true, especially the first one. Especially in cloud environments a bastion node / jumphost is used very often to connect to the VMs. Such a scenario can't be used with the current implementation.

Therefore I would suggest to move this task to the `prepare.yml` playbook. We can use `wait_for_connection` then, which respects the ssh config (jumphost, ports, ...) and the ansible config for these hosts. So both described use cases are now possible.

This can break existing configurations, if the `prepare.yml` is overridden within the actual molecule test.