### PR TITLE
Revert "podman: remove ansible_async_dir setting logic (#182)"

### DIFF
--- a/src/molecule_plugins/podman/playbooks/create.yml
+++ b/src/molecule_plugins/podman/playbooks/create.yml
@@ -8,6 +8,24 @@
   vars:
     podman_exec: "{{ lookup('env','MOLECULE_PODMAN_EXECUTABLE')|default('podman',true) }}"
   tasks:
+    - name: Get passwd entries for USER env
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ lookup('env', 'USER') }}"
+
+    - name: Get shell async_dir
+      ansible.builtin.set_fact:
+        _shell_async_dir: >-
+          {{ lookup('ansible.builtin.config', 'async_dir', plugin_type='shell', plugin_name='sh')
+             | regex_replace('^~', ansible_facts.getent_passwd[lookup('env', 'USER')][4]) }}
+
+    - name: Set async_dir for HOME env
+      ansible.builtin.set_fact:
+        ansible_async_dir: >-
+          {{ _shell_async_dir
+             | regex_replace('^' + ansible_facts.getent_passwd[lookup('env', 'USER')][4], lookup('env', 'HOME')) }}
+      when: lookup('env', 'HOME') != ansible_facts.getent_passwd[lookup('env', 'USER')][4]
+
     - name: Log into a container registry
       containers.podman.podman_login:
         certdir: >-

--- a/src/molecule_plugins/podman/playbooks/destroy.yml
+++ b/src/molecule_plugins/podman/playbooks/destroy.yml
@@ -8,6 +8,24 @@
   vars:
     podman_exec: "{{ lookup('env','MOLECULE_PODMAN_EXECUTABLE')|default('podman',true) }}"
   tasks:
+    - name: Get passwd entries for USER env
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ lookup('env', 'USER') }}"
+
+    - name: Get shell async_dir
+      ansible.builtin.set_fact:
+        _shell_async_dir: >-
+          {{ lookup('ansible.builtin.config', 'async_dir', plugin_type='shell', plugin_name='sh')
+             | regex_replace('^~', ansible_facts.getent_passwd[lookup('env', 'USER')][4]) }}
+
+    - name: Set async_dir for HOME env
+      ansible.builtin.set_fact:
+        ansible_async_dir: >-
+          {{ _shell_async_dir
+             | regex_replace('^' + ansible_facts.getent_passwd[lookup('env', 'USER')][4], lookup('env', 'HOME')) }}
+      when: lookup('env', 'HOME') != ansible_facts.getent_passwd[lookup('env', 'USER')][4]
+
     - name: Destroy molecule instance(s)
       ansible.builtin.shell: "{{ podman_exec }} container exists {{ item.name }} && {{ podman_exec }} rm -f {{ item.name }} || true"
       register: server

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ passenv =
     SSL_CERT_FILE
     TOXENV
     TWINE_*
+    USER
     OS_*
 allowlist_externals =
     bash


### PR DESCRIPTION
After upgrade to https://github.com/ansible-community/molecule-plugins/releases/tag/v23.5.3, I found that all my GitLab CI pipiline running with podman driver not working (e.g. https://gitlab.com/alvistack/docker-ubuntu/-/jobs/6148073273)

After debug I found that if disable https://github.com/ansible-community/molecule-plugins/blob/v23.5.3/src/molecule_plugins/podman/playbooks/create.yml#L167-L168 as below, the create will working fine:
```
    - name: Create molecule instance(s)
      containers.podman.podman_container:
      ...
      loop_control:
        label: "{{ item.name }}"      
      # async: 7200
      # poll: 0
      ---
```

So this lead me to the https://github.com/ansible-community/molecule-plugins/pull/182, which remove the `ansible_async_dir` logic.

After manually revert the commit https://github.com/ansible-community/molecule-plugins/commit/0244719340dbe33893e82e2f7fc7731365796285, my problem get fixed.

This reverts commit 0244719340dbe33893e82e2f7fc7731365796285.