### PR TITLE
fix #239 , use python-style templating instead of Jinja in the plugins login_cmd_template

### DIFF
--- a/src/molecule_plugins/azure/driver.py
+++ b/src/molecule_plugins/azure/driver.py
@@ -90,10 +90,10 @@ class Azure(Driver):
         connection_options = " ".join(self.ssh_connection_options)
 
         return (
-            "ssh {{address}} "
-            "-l {{user}} "
-            "-p {{port}} "
-            "-i {{identity_file}} "
+            "ssh {address} "
+            "-l {user} "
+            "-p {port} "
+            "-i {identity_file} "
             f"{connection_options}"
         )
 

--- a/src/molecule_plugins/ec2/driver.py
+++ b/src/molecule_plugins/ec2/driver.py
@@ -195,10 +195,10 @@ class EC2(Driver):
             connection_options = " ".join(self.ssh_connection_options)
 
             return (
-                "ssh {{address}} "
-                "-l {{user}} "
-                "-p {{port}} "
-                "-i {{identity_file}} "
+                "ssh {address} "
+                "-l {user} "
+                "-p {port} "
+                "-i {identity_file} "
                 f"{connection_options}"
             )
 

--- a/src/molecule_plugins/gce/driver.py
+++ b/src/molecule_plugins/gce/driver.py
@@ -94,10 +94,10 @@ class GCE(Driver):
         connection_options = " ".join(self.ssh_connection_options)
 
         return (
-            "ssh {{address}} "
-            "-l {{user}} "
-            "-p {{port}} "
-            "-i {{identity_file}} "
+            "ssh {address} "
+            "-l {user} "
+            "-p {port} "
+            "-i {identity_file} "
             f"{connection_options}"
         )
 

--- a/src/molecule_plugins/vagrant/driver.py
+++ b/src/molecule_plugins/vagrant/driver.py
@@ -149,10 +149,10 @@ class Vagrant(Driver):
         connection_options = " ".join(self.ssh_connection_options)
 
         return (
-            "ssh {{address}} "
-            "-l {{user}} "
-            "-p {{port}} "
-            "-i {{identity_file}} "
+            "ssh {address} "
+            "-l {user} "
+            "-p {port} "
+            "-i {identity_file} "
             f"{connection_options}"
         )
 


### PR DESCRIPTION
This file assumes Jinja templating for the port parameter and passes a Jinja-style "{{ port }}".

https://github.com/ansible/molecule/blob/main/src/molecule/command/login.py#L105

When it reaches molecule, it is subsituted in  this file and is done by python calling `.format()` on the string. That causes it to not render correctly and gives users issues running molecule login.

ref: https://github.com/ansible-community/molecule-plugins/issues/239