### PR TITLE
Openstack: add management of multi public network

### DIFF
--- a/src/molecule_plugins/openstack/playbooks/create.yml
+++ b/src/molecule_plugins/openstack/playbooks/create.yml
@@ -102,6 +102,7 @@
         image: "{{ item.image }}"
         key_name: "{{ key_name }}"
         flavor: "{{ item.flavor }}"
+        floating_ip_pools: "{{ item.floating_ip_pools | default(omit) }}"
         boot_from_volume: "{{ true if item.volume is defined and item.volume.size else false }}"
         terminate_volume: "{{ true if item.volume is defined and item.volume.size else false }}"
         volume_size: "{{ item.volume.size if item.volume is defined and item.volume.size else omit }}"


### PR DESCRIPTION
In the openstack plugins, it is not possible to
choose your public network, which is a problem when
 you are on a private cloud, you end up with the first
 public network on the list.

I encountered this error:
Timeout waiting for the floating IP to be attached.