### PR TITLE
patch podman login: omit certdir by default

### DIFF
--- a/src/molecule_plugins/podman/playbooks/create.yml
+++ b/src/molecule_plugins/podman/playbooks/create.yml
@@ -32,6 +32,7 @@
         - item.registry.credentials is defined
         - item.registry.credentials.username is defined
       changed_when: false
+      no_log: true
 
     - name: Check presence of custom Dockerfiles
       ansible.builtin.stat:

--- a/src/molecule_plugins/podman/playbooks/create.yml
+++ b/src/molecule_plugins/podman/playbooks/create.yml
@@ -13,6 +13,8 @@
         certdir: >-
           {% if lookup('env', 'DOCKER_CERT_PATH') %}
           {{ item.cert_path | default(lookup('env', 'DOCKER_CERT_PATH') + '/cert.pem') }}
+          {% else %}
+          {{ item.cert_path | default(omit)}}
           {% endif %}
         executable: "{{ podman_exec }}"
         username: "{{ item.registry.credentials.username }}"


### PR DESCRIPTION
Resolves #248

This is an alternative to #249. Instead of reverting to the use of `ansible.builtin.command`, we can also use `default(omit, true)` in the if-statement in the template being passed as value to the `certdir` argument.

However, this only seems to work when this if-statement is on one line (presumably, the template resulting template is not empty but contains newlines when that is not the case).