### PR TITLE
podman: add podman executable on build image task

### DIFF
--- a/src/molecule_plugins/podman/playbooks/create.yml
+++ b/src/molecule_plugins/podman/playbooks/create.yml
@@ -77,6 +77,7 @@
             {% if item.item.pull is defined %}--pull={{ item.item.pull }}{% endif %}
           file: "{{ item.dest }}"
         name: "molecule_local/{{ item.item.image }}"
+        executable: "{{ podman_exec }}"
         path: "{{ molecule_scenario_directory }}"
         pull: "{{ item.item.pull | default(omit) }}"
       loop: "{{ platforms.results }}"


### PR DESCRIPTION
### Description

Add missing `executable` argument to the task `Build an Ansible compatible image`, as for the other tasks.

### Links

Fixes #253 