### PR TITLE
Openstack add public IP options

### DIFF
--- a/doc/openstack/platforms.rst
+++ b/doc/openstack/platforms.rst
@@ -43,6 +43,12 @@ security_group.rules[].port_min Starting port (can't be used with port)
 security_group.rules[].port_max Ending port (can't be used with port)
 security_group.rules[].type     IPv4 or IPv6, default 'IPv4'
 user                            Default user of image
+auto_ip                         Ensure instance has public IP, mutually \
+                                exclusive with floating_ip_pools, \
+                                default = true
+floating_ip_pools               List of floating pool IP names to choose a \
+                                floating IP from, mutually exclusive with \
+                                auto_ip, (optional)
 volume                          Mapping of volume settings (optional if \
                                 flavor provides volume)
 volume.size                     Size of volume (GB)
@@ -96,6 +102,8 @@ Examples
         flavor: m1.small
         image: Debian_10
         user: debian
+        floating_ip_pools: # mutually exclusive with auto_ip
+          - 1.2.3.4
         network:
           name: molecule
           router:
@@ -142,6 +150,7 @@ Examples
         falvor: m1.tiny
         image: Ubuntu_2004
         user: ubuntu
+        auto_ip: false # do not assign a public IP
         security_group:
           name: molecule # use security group from debian10 instance
         network:

--- a/doc/openstack/platforms.rst
+++ b/doc/openstack/platforms.rst
@@ -147,7 +147,7 @@ Examples
         network:
           name: molecule # use network from debian10 instance
       - name: ubuntu2004
-        falvor: m1.tiny
+        flavor: m1.tiny
         image: Ubuntu_2004
         user: ubuntu
         auto_ip: false # do not assign a public IP

--- a/src/molecule_plugins/openstack/driver.py
+++ b/src/molecule_plugins/openstack/driver.py
@@ -27,6 +27,8 @@ class Openstack(Driver):
             flavor: m1.small
             image: Ubuntu_20.04
             user: ubuntu
+            floating_ip_pools: # mutually exclusive with auto_ip
+              - 1.2.3.4
             security_group:
                 name: molecule-sec
                 description: Molecule test

--- a/src/molecule_plugins/openstack/playbooks/create.yml
+++ b/src/molecule_plugins/openstack/playbooks/create.yml
@@ -102,6 +102,8 @@
         image: "{{ item.image }}"
         key_name: "{{ key_name }}"
         flavor: "{{ item.flavor }}"
+        floating_ip_pools: "{{ item.floating_ip_pools if item.floating_ip_pools is defined and item.floating_ip_pools else omit }}"
+        auto_ip: "{{ item.auto_ip if item.auto_ip is defined else omit }}"
         boot_from_volume: "{{ true if item.volume is defined and item.volume.size else false }}"
         terminate_volume: "{{ true if item.volume is defined and item.volume.size else false }}"
         volume_size: "{{ item.volume.size if item.volume is defined and item.volume.size else omit }}"

--- a/src/molecule_plugins/openstack/playbooks/create.yml
+++ b/src/molecule_plugins/openstack/playbooks/create.yml
@@ -102,7 +102,7 @@
         image: "{{ item.image }}"
         key_name: "{{ key_name }}"
         flavor: "{{ item.flavor }}"
-        floating_ip_pools: "{{ item.floating_ip_pools if item.floating_ip_pools is defined and item.floating_ip_pools else omit }}"
+        floating_ip_pools: "{{ item.floating_ip_pools if item.floating_ip_pools is defined and item.floating_ip_pools | length > 0 else omit }}"
         auto_ip: "{{ item.auto_ip if item.auto_ip is defined else omit }}"
         boot_from_volume: "{{ true if item.volume is defined and item.volume.size else false }}"
         terminate_volume: "{{ true if item.volume is defined and item.volume.size else false }}"


### PR DESCRIPTION
Adds options to the OpenStack plugin to set a list of floating IP pools from which to choose a floating IP or to turn off the allocation of a public IP.

Supersedes https://github.com/ansible-community/molecule-plugins/pull/229 and https://github.com/ansible-community/molecule-plugins/pull/243