### PR TITLE
podman: default the hostname to the name of the platform

### DIFF
--- a/src/molecule_plugins/podman/playbooks/create.yml
+++ b/src/molecule_plugins/podman/playbooks/create.yml
@@ -146,7 +146,7 @@
         etc_hosts: "{{ item.etc_hosts | default(omit) }}"
         executable: "{{ podman_exec }}"
         expose: "{{ item.exposed_ports | default(omit) }}"
-        hostname: "{{ item.hostname | default(omit) }}"
+        hostname: "{{ item.hostname | default(item.name) }}"
         image: "{{ item.pre_build_image | default(false) | ternary('', 'molecule_local/') }}{{ item.image }}"
         ip: "{{ item.ip | default(omit) }}"
         label:


### PR DESCRIPTION
This was the case in the past (and is still the case for the Docker
driver), but was accidentally changed in an unrelated refactoring.

Fixes: e9d56496261807a5174c1347123b49e629c2490b
