### PR TITLE
docker: allow `import docker` in `reset` to fail

### DIFF
--- a/src/molecule_plugins/docker/driver.py
+++ b/src/molecule_plugins/docker/driver.py
@@ -255,7 +255,11 @@ class Docker(Driver):
         self._passed_sanity = True
 
     def reset(self):
-        import docker
+        # maybe use self.sanity_check instead?
+        try:
+            import docker
+        except ImportError:
+            return
 
         client = docker.from_env()
         for c in client.containers.list(filters={"label": "owner=molecule"}):


### PR DESCRIPTION
* if the user hasn't installed the `[docker]` extra, they won't have
  `docker` to `import`, so don't make `import docker` required in the
  docker driver's `reset`.
* fixes #166

an alternative implementation could be

```py
for driver in drivers():
    with suppress(ImportError):
        driver.reset()
```

in this section: https://github.com/ansible/molecule/blob/4e2592e5d77b181133243b8b685933f6daff3897/src/molecule/command/reset.py#L49

pros of this PR's implementation:

* scoped to just docker driver

pros of `with suppress(ImportError)` in `molecule`:

* driver authors don't have to remember to `try/except ImportError: pass` in their `reset()`