### PR TITLE
implement reset for podman driver

### DIFF
--- a/src/molecule_plugins/podman/driver.py
+++ b/src/molecule_plugins/podman/driver.py
@@ -246,4 +246,4 @@ class Podman(Driver):
 
     def reset(self):
         # keep `--filter` in sync with playbooks/create.yml
-        run_command(["podman", "rm", "--force", "--filter=owner=molecule"])
+        run_command(["podman", "rm", "--force", "--filter=label=owner=molecule"])

--- a/src/molecule_plugins/podman/driver.py
+++ b/src/molecule_plugins/podman/driver.py
@@ -30,7 +30,7 @@ from packaging.version import Version
 from molecule import logger, util
 from molecule.api import Driver, MoleculeRuntimeWarning
 from molecule.constants import RC_SETUP_ERROR
-from molecule.util import sysexit_with_message
+from molecule.util import run_command, sysexit_with_message
 
 log = logger.get_logger(__name__)
 
@@ -243,3 +243,7 @@ class Podman(Driver):
     def required_collections(self) -> dict[str, str]:
         """Return collections dict containing names and versions required."""
         return {"containers.podman": "1.7.0", "ansible.posix": "1.3.0"}
+
+    def reset(self):
+        # keep `--filter` in sync with playbooks/create.yml
+        run_command(["podman", "rm", "--force", "--filter=owner=molecule"])

--- a/src/molecule_plugins/podman/playbooks/create.yml
+++ b/src/molecule_plugins/podman/playbooks/create.yml
@@ -149,7 +149,7 @@
         hostname: "{{ item.hostname | default(omit) }}"
         image: "{{ item.pre_build_image | default(false) | ternary('', 'molecule_local/') }}{{ item.image }}"
         ip: "{{ item.ip | default(omit) }}"
-        labels:
+        label:
           owner: "molecule" # keep in sync with ../driver.py:Podman.reset()
         network: "{{ item.network | default(omit) }}"
         pid: "{{ item.pid_mode | default(omit) }}"

--- a/src/molecule_plugins/podman/playbooks/create.yml
+++ b/src/molecule_plugins/podman/playbooks/create.yml
@@ -149,6 +149,8 @@
         hostname: "{{ item.hostname | default(omit) }}"
         image: "{{ item.pre_build_image | default(false) | ternary('', 'molecule_local/') }}{{ item.image }}"
         ip: "{{ item.ip | default(omit) }}"
+        labels:
+          owner: "molecule" # keep in sync with ../driver.py:Podman.reset()
         network: "{{ item.network | default(omit) }}"
         pid: "{{ item.pid_mode | default(omit) }}"
         privileged: "{{ item.privileged | default(omit) }}"


### PR DESCRIPTION
* when the podman driver runs the `create` playbook, we'll add a
  `owner=molecule` label to the containers we create
* in `reset`, we'll delete containers (eventually everything?) that has
  the label `owner=molecule`
