### PR TITLE
GCE: Added network tags support

### DIFF
--- a/src/molecule_plugins/gce/playbooks/tasks/create_linux_instance.yml
+++ b/src/molecule_plugins/gce/playbooks/tasks/create_linux_instance.yml
@@ -28,6 +28,7 @@
         subnetwork:
           selfLink: "{{ gcp_snet }}"
         access_configs: "{{ [{'name': 'instance_ip', 'type': 'ONE_TO_ONE_NAT'}] if molecule_yml.driver.external_access else [] }}"
+    tags: "{{ item.tags | default(omit) }}"
     zone: "{{ item.zone | default(molecule_yml.driver.region + '-b') }}"
     project: "{{ gcp_project_id }}"
     scopes: "{{ molecule_yml.driver.scopes | default(['https://www.googleapis.com/auth/compute'], True) }}"

--- a/src/molecule_plugins/gce/playbooks/tasks/create_windows_instance.yml
+++ b/src/molecule_plugins/gce/playbooks/tasks/create_windows_instance.yml
@@ -20,6 +20,7 @@
         subnetwork:
           selfLink: "{{ gcp_snet }}"
         access_configs: "{{ [{'name': 'instance_ip', 'type': 'ONE_TO_ONE_NAT'}] if molecule_yml.driver.external_access else [] }}"
+    tags: "{{ item.tags | default(omit) }}"
     zone: "{{ item.zone | default(molecule_yml.driver.region + '-b') }}"
     project: "{{ gcp_project_id }}"
     scopes: "{{ molecule_yml.driver.scopes | default(['https://www.googleapis.com/auth/compute'], True) }}"


### PR DESCRIPTION
GCE: Added network tags support
Tags are used to identify valid sources or targets for network firewalls. 
For example: It allows to get ssh access to run Molecule tests

In molecule.yml

platforms:
  - name: 'molecule-instance'
    tags:
      items:
         - 'allow-ssh'