### PR TITLE
GCE: Added support multiple disks

### DIFF
--- a/src/molecule_plugins/gce/playbooks/tasks/create_linux_instance.yml
+++ b/src/molecule_plugins/gce/playbooks/tasks/create_linux_instance.yml
@@ -5,14 +5,6 @@
     path: "{{ ssh_identity_file }}"
   register: keypair
 
-- name: Set default boot disk
-  ansible.builtin.set_fact:
-    disks:
-      - auto_delete: true
-        boot: true
-        initialize_params:
-          source_image: "projects/debian-cloud/global/images/family/debian-10"
-
 - name: "Create molecule Linux instance(s)"
   google.cloud.gcp_compute_instance:
     state: present
@@ -22,7 +14,7 @@
       ssh-keys: "{{ lookup('env', 'USER') }}:{{ keypair.public_key }}"
     scheduling:
       preemptible: "{{ item.preemptible | default(false) }}"
-    disks: "{{ item.disks | default(disks,true) }}"
+    disks: "{{ item.disks }}"
     network_interfaces:
       - network:
           selfLink: "{{ gcp_net }}"

--- a/src/molecule_plugins/gce/playbooks/tasks/create_linux_instance.yml
+++ b/src/molecule_plugins/gce/playbooks/tasks/create_linux_instance.yml
@@ -5,6 +5,14 @@
     path: "{{ ssh_identity_file }}"
   register: keypair
 
+- name: Set default boot disk
+  ansible.builtin.set_fact:
+    disks:
+      - auto_delete: true
+        boot: true
+        initialize_params:
+          source_image: "projects/debian-cloud/global/images/family/debian-10"
+
 - name: "Create molecule Linux instance(s)"
   google.cloud.gcp_compute_instance:
     state: present
@@ -14,14 +22,7 @@
       ssh-keys: "{{ lookup('env', 'USER') }}:{{ keypair.public_key }}"
     scheduling:
       preemptible: "{{ item.preemptible | default(false) }}"
-    disks:
-      - auto_delete: true
-        boot: true
-        initialize_params:
-          disk_size_gb: "{{ item.disk_size_gb | default(omit) }}"
-          source_image: "{{ item.image | default('projects/debian-cloud/global/images/family/debian-10') }}"
-          source_image_encryption_key:
-            raw_key: "{{ item.image_encryption_key | default(omit) }}"
+    disks: "{{ item.disks | default(disks,true) }}"
     network_interfaces:
       - network:
           selfLink: "{{ gcp_net }}"

--- a/src/molecule_plugins/gce/playbooks/tasks/create_windows_instance.yml
+++ b/src/molecule_plugins/gce/playbooks/tasks/create_windows_instance.yml
@@ -1,12 +1,4 @@
 ---
-- name: Set default boot disk
-  ansible.builtin.set_fact:
-    disks:
-      - auto_delete: true
-        boot: true
-        initialize_params:
-          source_image: "projects/windows-cloud/global/images/family/windows-2019"
-
 - name: Create molecule Windows instance(s)
   google.cloud.gcp_compute_instance:
     state: present
@@ -14,7 +6,7 @@
     machine_type: "{{ item.machine_type | default('n1-standard-1') }}"
     scheduling:
       preemptible: "{{ item.preemptible | default(false) }}"
-    disks: "{{ item.disks | default(disks,true) }}"
+    disks: "{{ item.disks }}"
     network_interfaces:
       - network:
           selfLink: "{{ gcp_net }}"

--- a/src/molecule_plugins/gce/playbooks/tasks/create_windows_instance.yml
+++ b/src/molecule_plugins/gce/playbooks/tasks/create_windows_instance.yml
@@ -1,4 +1,12 @@
 ---
+- name: Set default boot disk
+  ansible.builtin.set_fact:
+    disks:
+      - auto_delete: true
+        boot: true
+        initialize_params:
+          source_image: "projects/windows-cloud/global/images/family/windows-2019"
+
 - name: Create molecule Windows instance(s)
   google.cloud.gcp_compute_instance:
     state: present
@@ -6,14 +14,7 @@
     machine_type: "{{ item.machine_type | default('n1-standard-1') }}"
     scheduling:
       preemptible: "{{ item.preemptible | default(false) }}"
-    disks:
-      - auto_delete: true
-        boot: true
-        initialize_params:
-          disk_size_gb: "{{ item.disk_size_gb | default(omit) }}"
-          source_image: "{{ item.image | default('projects/windows-cloud/global/images/family/windows-2019') }}"
-          source_image_encryption_key:
-            raw_key: "{{ item.image_encryption_key | default(omit) }}"
+    disks: "{{ item.disks | default(disks,true) }}"
     network_interfaces:
       - network:
           selfLink: "{{ gcp_net }}"


### PR DESCRIPTION
GCE: Added support multiple disks

In some cases, additional disks are required for testing Ansible roles.

Removed disk created by default to support multiple disks.

See example: 

driver:
  name: 'gce'

platforms:
  - name: 'molecule-instance'
    disks:
      - auto_delete: true
        boot: true
        initialize_params:
          source_image: 'projects/<project_id>/global/images/family/<image_family_name>'
      - auto_delete: true
        initialize_params:
          disk_size_gb: '10'
          disk_type: 'pd-standard'