### PR TITLE
GCE: added metadata startup-script support for Linux

### DIFF
--- a/src/molecule_plugins/gce/playbooks/tasks/create_linux_instance.yml
+++ b/src/molecule_plugins/gce/playbooks/tasks/create_linux_instance.yml
@@ -12,7 +12,7 @@
     machine_type: "{{ item.machine_type | default('n1-standard-1') }}"
     metadata:
       ssh-keys: "{{ lookup('env', 'USER') }}:{{ keypair.public_key }}"
-      startup-script: "{{ lookup('file', item.startup_script_path) | default(omit, true) }}"
+      startup-script: "{{ lookup('file', item.startup_script_path) if (item.startup_script_path is defined and item.startup_script_path | length > 0) else omit }}"
     scheduling:
       preemptible: "{{ item.preemptible | default(false) }}"
     disks:

--- a/src/molecule_plugins/gce/playbooks/tasks/create_linux_instance.yml
+++ b/src/molecule_plugins/gce/playbooks/tasks/create_linux_instance.yml
@@ -12,6 +12,7 @@
     machine_type: "{{ item.machine_type | default('n1-standard-1') }}"
     metadata:
       ssh-keys: "{{ lookup('env', 'USER') }}:{{ keypair.public_key }}"
+      startup-script: "{{ lookup('file', item.startup_script_path) | default(omit, true) }}"
     scheduling:
       preemptible: "{{ item.preemptible | default(false) }}"
     disks:

--- a/src/molecule_plugins/gce/playbooks/tasks/create_windows_instance.yml
+++ b/src/molecule_plugins/gce/playbooks/tasks/create_windows_instance.yml
@@ -5,7 +5,7 @@
     name: "{{ item.name }}"
     machine_type: "{{ item.machine_type | default('n1-standard-1') }}"
     metatdata:
-      startup-script: "{{ lookup('file', item.startup_script_path) | default(omit, true) }}"
+      startup-script: "{{ lookup('file', item.startup_script_path) if (item.startup_script_path is defined and item.startup_script_path | length > 0) else omit }}"
     scheduling:
       preemptible: "{{ item.preemptible | default(false) }}"
     disks:

--- a/src/molecule_plugins/gce/playbooks/tasks/create_windows_instance.yml
+++ b/src/molecule_plugins/gce/playbooks/tasks/create_windows_instance.yml
@@ -4,8 +4,6 @@
     state: present
     name: "{{ item.name }}"
     machine_type: "{{ item.machine_type | default('n1-standard-1') }}"
-    metatdata:
-      startup-script: "{{ lookup('file', item.startup_script_path) if (item.startup_script_path is defined and item.startup_script_path | length > 0) else omit }}"
     scheduling:
       preemptible: "{{ item.preemptible | default(false) }}"
     disks:

--- a/src/molecule_plugins/gce/playbooks/tasks/create_windows_instance.yml
+++ b/src/molecule_plugins/gce/playbooks/tasks/create_windows_instance.yml
@@ -4,6 +4,8 @@
     state: present
     name: "{{ item.name }}"
     machine_type: "{{ item.machine_type | default('n1-standard-1') }}"
+    metatdata:
+      startup-script: "{{ lookup('file', item.startup_script_path) | default(omit, true) }}"
     scheduling:
       preemptible: "{{ item.preemptible | default(false) }}"
     disks:


### PR DESCRIPTION
GCE: added metadata startup-script support for Linux

In some cases, the Ansible playbook depends on metadata startup-script.

startup_script_path key can be omitted if it is not required.

See molecule.yml code snippet:

`
driver:
  name: 'gce'
  instance_os_type: linux
platforms:
  - name: 'molecule-instance'
      startup_script_path: '${MOLECULE_PROJECT_DIRECTORY}/startup-script.sh'
`

