### PR TITLE
EC2: Change logic of deleting resources

### DIFF
--- a/src/molecule_plugins/ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/src/molecule_plugins/ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -111,11 +111,6 @@
           until: ec2_instances is finished
           retries: 300
 
-        - name: Write Molecule instance configs
-          ansible.builtin.copy:
-            dest: "{{ molecule_instance_config }}"
-            content: "{{ {} | to_yaml }}"
-
         - name: Destroy ephemeral security groups (if needed)
           amazon.aws.ec2_security_group:
             profile: "{{ item.aws_profile | default(omit) }}"
@@ -142,4 +137,9 @@
             index_var: index
             label: "{{ item.name }}"
           when: item.key_inject_method == "ec2"
+
+        - name: Write Molecule instance configs
+          ansible.builtin.copy:
+            dest: "{{ molecule_instance_config }}"
+            content: "{{ {} | to_yaml }}"
 {%- endraw %}


### PR DESCRIPTION
This PR changes the logic of deleting resources of the EC2 driver. Without that change security groups and keypairs will stay because the tasks will be skipped.

The tasks `Write Molecule instance configs` changes the when condition of the block immediately. This will skip the following tasks regardless of their when conditions. Moving the tasks `Write Molecule instance configs` to the end of the block will execute the cleanup of Security groups and keypairs according to their own when condition.