### PR TITLE
bug: missing until for retry in gce plugin

### DIFF
--- a/src/molecule_plugins/gce/playbooks/tasks/create_linux_instance.yml
+++ b/src/molecule_plugins/gce/playbooks/tasks/create_linux_instance.yml
@@ -61,6 +61,8 @@
     host: "{{ item.networkInterfaces.0.accessConfigs.0.natIP if molecule_yml.driver.external_access else item.networkInterfaces.0.networkIP }}"
     search_regex: SSH
     delay: 10
+  loop: "{{ server.results }}"
+  register: waitfor
+  until: waitfor.failed == false
   retries: 6
   delay: 10
-  loop: "{{ server.results }}"

--- a/src/molecule_plugins/gce/playbooks/tasks/create_windows_instance.yml
+++ b/src/molecule_plugins/gce/playbooks/tasks/create_windows_instance.yml
@@ -51,6 +51,10 @@
     host: "{{ item.networkInterfaces.0.accessConfigs.0.natIP if molecule_yml.driver.external_access else item.networkInterfaces.0.networkIP }}"
     delay: 10
   loop: "{{ server.results }}"
+  register: waitfor
+  until: waitfor.failed == false
+  retries: 6
+  delay: 10
 
 - name: Prepare Windows User
   ansible.builtin.script: >


### PR DESCRIPTION
Missing the until key for the wait_for module in the gce plugin. Apparently, it doesn't work when the `until` is missing.
![image](https://github.com/user-attachments/assets/d58b26d3-575f-4826-8a75-c17ff530756e)
