### PR TITLE
Fix deprecated xfreerdp option for winrm targets of EC2 plugin

### DIFF
--- a/src/molecule_plugins/ec2/driver.py
+++ b/src/molecule_plugins/ec2/driver.py
@@ -182,7 +182,7 @@ class EC2(Driver):
                 '"/u:{}" '
                 '"/p:{}" '
                 "/v:{} "
-                "/cert-tofu "
+                "/cert:tofu "
                 "+clipboard "
                 "/grab-keyboard".format(
                     ansible_connection_options["ansible_user"],


### PR DESCRIPTION
Using the `molecule login` command with the Molecule EC2 plugin and a Windows target (winrm connection method) fails with the error:

```
[16:20:02:648] [83832:f0258240] [ERROR][com.winpr.commandline] - [log_error]: Failed at index 4 [/cert-tofu]: Unexpected keyword
```

The docs for FreeRDP state that the `cert-tofu` CLI option has been deprecated and changed to `cert:tofu`. This option skips the certificate validation step, which may sense for this use case. See https://manpages.debian.org/unstable/freerdp2-x11/xfreerdp.1.en.html.

I tested my fix locally, and changing `/cert-tofu` to `/cert:tofu` fixed the issue. I am running molecule on an M4 macbook with FreeRDP version 3.10.2.