### PR TITLE
[Molecule v25.1.0] Replace util.run_command with app.run_command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
       TOX_PARALLEL_NO_SPINNER: 1
 
     steps:
-      - name: Switch to using Python 3.9 by default
+      - name: Switch to using Python 3.10 by default
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.10
 
       - name: Install tox
         run: >-

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -23,9 +23,9 @@ jobs:
         id: generate_matrix
         uses: coactions/dynamic-matrix@v1
         with:
-          min_python: "3.9"
+          min_python: "3.10"
           max_python: "3.12"
-          default_python: "3.9" # used by jobs in other_names
+          default_python: "3.10" # used by jobs in other_names
           other_names: |
             lint
             pkg

--- a/conftest.py
+++ b/conftest.py
@@ -3,10 +3,12 @@ import os
 import random
 import shutil
 import string
+from pathlib import Path
 
 import pytest
 
-from molecule import config, logger, util
+from molecule import config, logger
+from molecule.app import get_app
 from molecule.scenario import ephemeral_directory
 
 LOG = logger.get_logger(__name__)
@@ -18,7 +20,7 @@ def run_command(cmd, env=os.environ, log=True):
         if log:
             cmd = _rebake_command(cmd, env)
         cmd = cmd.bake(_truncate_exc=False)
-    return util.run_command(cmd, env=env)
+    return get_app(Path()).run_command(cmd, env=env)
 
 
 def _rebake_command(cmd, env, out=LOG.info, err=LOG.error):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 # https://peps.python.org/pep-0621/#readme
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["version"]
 name = "molecule-plugins"
 description = "Molecule Plugins"
@@ -26,7 +26,6 @@ classifiers = [
   "Operating System :: MacOS",
   "Operating System :: POSIX",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -40,7 +39,7 @@ classifiers = [
 keywords = ["ansible", "testing", "molecule", "plugin"]
 dependencies = [
     # molecule plugins are not allowed to mention Ansible as a direct dependency
-    "molecule >= 6.0.0a1",
+    "molecule >= 25.1.0",
 ]
 
 [project.urls]
@@ -52,7 +51,7 @@ changelog = "https://github.com/ansible-community/molecule-plugins/releases"
 [project.optional-dependencies]
 test = [
     "pytest-helpers-namespace >= 2019.1.8",
-    "molecule[test] >= 6.0.0a1"
+    "molecule[test] >= 25.1.0"
 ]
 azure = []
 docker = [
@@ -89,7 +88,7 @@ openstack = [
 ]
 
 [tool.ruff]
-ignore = [
+lint.ignore = [
   "E501", # we use black
   # we deliberately ignore these:
   "EM102",
@@ -101,6 +100,7 @@ ignore = [
   "B028",
   "BLE",
   "C901",
+  "COM812",
   "D",
   "DTZ",
   "FBT",
@@ -119,15 +119,15 @@ ignore = [
   "FIX002",
   "TRY",
 ]
-select = ["ALL"]
+lint.select = ["ALL"]
 target-version = "py39"
 # Same as Black.
 line-length = 88
 
-[tool.ruff.flake8-pytest-style]
+[tool.ruff.lint.flake8-pytest-style]
 parametrize-values-type = "tuple"
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["molecule_plugins"]
 
 [project.entry-points."molecule.driver"]

--- a/src/molecule_plugins/docker/driver.py
+++ b/src/molecule_plugins/docker/driver.py
@@ -19,7 +19,6 @@
 #  DEALINGS IN THE SOFTWARE.
 """Docker Driver Module."""
 
-
 import os
 
 from molecule import logger

--- a/src/molecule_plugins/podman/driver.py
+++ b/src/molecule_plugins/podman/driver.py
@@ -19,9 +19,9 @@
 #  DEALINGS IN THE SOFTWARE.
 """Podman Driver Module."""
 
-
 import os
 import warnings
+from pathlib import Path
 from shutil import which
 
 from ansible_compat.runtime import Runtime
@@ -29,8 +29,9 @@ from packaging.version import Version
 
 from molecule import logger, util
 from molecule.api import Driver, MoleculeRuntimeWarning
+from molecule.app import get_app
 from molecule.constants import RC_SETUP_ERROR
-from molecule.util import run_command, sysexit_with_message
+from molecule.util import sysexit_with_message
 
 log = logger.get_logger(__name__)
 
@@ -246,4 +247,6 @@ class Podman(Driver):
 
     def reset(self):
         # keep `--filter` in sync with playbooks/create.yml
-        run_command(["podman", "rm", "--force", "--filter=label=owner=molecule"])
+        get_app(Path()).run_command(
+            ["podman", "rm", "--force", "--filter=label=owner=molecule"]
+        )

--- a/src/molecule_plugins/vagrant/modules/vagrant.py
+++ b/src/molecule_plugins/vagrant/modules/vagrant.py
@@ -503,10 +503,7 @@ class VagrantClient:
         try:
             return self._vagrant.conf(vm_name=instance_name)
         except Exception:
-            msg = "Failed to get vagrant config for {}: See log file '{}'".format(
-                instance_name,
-                self._get_stderr_log(),
-            )
+            msg = f"Failed to get vagrant config for {instance_name}: See log file '{self._get_stderr_log()}'"
             with open(self._get_stderr_log(), encoding="utf-8") as f:
                 self.result["stderr"] = f.read()
                 self._module.fail_json(msg=msg, **self.result)
@@ -517,10 +514,7 @@ class VagrantClient:
 
             return {"name": s.name, "state": s.state, "provider": s.provider}
         except Exception:
-            msg = "Failed to get status for {}: See log file '{}'".format(
-                instance_name,
-                self._get_stderr_log(),
-            )
+            msg = f"Failed to get status for {instance_name}: See log file '{self._get_stderr_log()}'"
             with open(self._get_stderr_log(), encoding="utf-8") as f:
                 self.result["stderr"] = f.read()
                 self._module.fail_json(msg=msg, **self.result)
@@ -697,7 +691,7 @@ class VagrantClient:
     def _get_stderr_log(self):
         return self._get_vagrant_log("err")
 
-    def _get_vagrant_log(self, __type):
+    def _get_vagrant_log(self, __type, /):
         return os.path.join(self._config["workdir"], f"vagrant.{__type}")
 
 

--- a/test/azure/functional/test_azure.py
+++ b/test/azure/functional/test_azure.py
@@ -20,12 +20,13 @@
 #  DEALINGS IN THE SOFTWARE.
 
 import os
+from pathlib import Path
 
 import pytest
 
 from conftest import change_dir_to
 from molecule import logger
-from molecule.util import run_command
+from molecule.app import get_app
 
 LOG = logger.get_logger(__name__)
 
@@ -33,7 +34,7 @@ LOG = logger.get_logger(__name__)
 def test_azure_command_init_scenario(temp_dir):
     role_directory = os.path.join(temp_dir.strpath, "test_init")
     cmd = ["ansible-galaxy", "role", "init", "test_init"]
-    result = run_command(cmd)
+    result = get_app(Path()).run_command(cmd)
     assert result.returncode == 0
 
     with change_dir_to(role_directory):
@@ -47,7 +48,7 @@ def test_azure_command_init_scenario(temp_dir):
             "-a",
             'path=meta/main.yml line="  namespace: foo" insertafter="  author: your name"',
         ]
-        run_command(cmd_meta, check=True)
+        get_app(Path()).run_command(cmd_meta, check=True)
 
         # we need to inject namespace info into tests/test.yml
         cmd_tests = [
@@ -59,7 +60,7 @@ def test_azure_command_init_scenario(temp_dir):
             "-a",
             'path=tests/test.yml line="    - foo.test_init" regex="^(.*)  - test_init"',
         ]
-        run_command(cmd_tests, check=True)
+        get_app(Path()).run_command(cmd_tests, check=True)
 
         molecule_directory = pytest.helpers.molecule_directory()
         scenario_directory = os.path.join(molecule_directory, "test_scenario")
@@ -71,7 +72,7 @@ def test_azure_command_init_scenario(temp_dir):
             "--driver-name",
             "azure",
         ]
-        result = run_command(cmd)
+        result = get_app(Path()).run_command(cmd)
         assert result.returncode == 0
 
         assert os.path.isdir(scenario_directory)
@@ -82,5 +83,5 @@ def test_azure_command_init_scenario(temp_dir):
         # temporary trick to pass on CI/CD
         if "AZURE_SECRET" in os.environ:
             cmd = ["molecule", "test", "-s", "test-scenario"]
-            result = run_command(cmd)
+            result = get_app(Path()).run_command(cmd)
             assert result.returncode == 0

--- a/test/containers/functional/test_containers.py
+++ b/test/containers/functional/test_containers.py
@@ -19,11 +19,13 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 """Functional Tests."""
+
 import os
+from pathlib import Path
 
 from conftest import change_dir_to, molecule_directory
 from molecule import logger
-from molecule.util import run_command
+from molecule.app import get_app
 
 LOG = logger.get_logger(__name__)
 
@@ -40,7 +42,7 @@ def test_containers_command_init_scenario(temp_dir):
             "--driver-name",
             "containers",
         ]
-        result = run_command(cmd)
+        result = get_app(Path()).run_command(cmd)
         assert result.returncode == 0
 
         assert os.path.isdir(scenario_directory)
@@ -49,5 +51,5 @@ def test_containers_command_init_scenario(temp_dir):
         # is shorter but comprehensive enough to test the most important
         # functionality: destroy, dependency, create, prepare, converge
         cmd = ["molecule", "check", "-s", "default"]
-        result = run_command(cmd)
+        result = get_app(Path()).run_command(cmd)
         assert result.returncode == 0

--- a/test/docker/test_func.py
+++ b/test/docker/test_func.py
@@ -4,12 +4,13 @@ import os
 import pathlib
 import shutil
 import subprocess
+from pathlib import Path
 
 import pytest
 
 from conftest import change_dir_to
 from molecule import logger
-from molecule.util import run_command
+from molecule.app import get_app
 
 LOG = logger.get_logger(__name__)
 
@@ -40,21 +41,25 @@ def test_command_init_and_test_scenario(tmp_path: pathlib.Path, DRIVER: str) -> 
             "--driver-name",
             DRIVER,
         ]
-        result = run_command(cmd)
+        result = get_app(tmp_path).run_command(cmd)
         assert result.returncode == 0
 
         assert scenario_directory.exists()
 
         # run molecule reset as this may clean some leftovers from other
         # test runs and also ensure that reset works.
-        result = run_command(["molecule", "reset"])  # default scenario
+        result = get_app(tmp_path).run_command(
+            ["molecule", "reset"]
+        )  # default scenario
         assert result.returncode == 0
 
-        result = run_command(["molecule", "reset", "-s", scenario_name])
+        result = get_app(tmp_path).run_command(
+            ["molecule", "reset", "-s", scenario_name]
+        )
         assert result.returncode == 0
 
         cmd = ["molecule", "--debug", "test", "-s", scenario_name]
-        result = run_command(cmd)
+        result = get_app(tmp_path).run_command(cmd)
         assert result.returncode == 0
 
 
@@ -63,7 +68,7 @@ def test_command_static_scenario() -> None:
     """Validate that the scenario we included with code still works."""
     cmd = ["molecule", "test"]
 
-    result = run_command(cmd)
+    result = get_app(Path()).run_command(cmd)
     assert result.returncode == 0
 
 
@@ -72,7 +77,7 @@ def test_dockerfile_with_context() -> None:
     """Verify that Dockerfile.j2 with context works."""
     with change_dir_to("test/docker/scenarios/with-context"):
         cmd = ["molecule", "--debug", "test"]
-        result = run_command(cmd)
+        result = get_app(Path()).run_command(cmd)
         assert result.returncode == 0
 
 
@@ -82,5 +87,5 @@ def test_env_substitution() -> None:
     os.environ["MOLECULE_ROLE_IMAGE"] = "debian:bullseye"
     with change_dir_to("test/docker/scenarios/env-substitution"):
         cmd = ["molecule", "--debug", "test"]
-        result = run_command(cmd)
+        result = get_app(Path()).run_command(cmd)
         assert result.returncode == 0

--- a/test/ec2/functional/test_ec2.py
+++ b/test/ec2/functional/test_ec2.py
@@ -20,12 +20,13 @@
 #  DEALINGS IN THE SOFTWARE.
 
 import os
+from pathlib import Path
 
 import pytest
 
 from conftest import change_dir_to, metadata_lint_update
 from molecule import logger
-from molecule.util import run_command
+from molecule.app import get_app
 
 LOG = logger.get_logger(__name__)
 
@@ -34,7 +35,7 @@ LOG = logger.get_logger(__name__)
 def test_ec2_command_init_scenario(temp_dir):
     role_directory = os.path.join(temp_dir.strpath, "test-init")
     cmd = ["molecule", "init", "role", "test-init"]
-    assert run_command(cmd).returncode == 0
+    assert get_app(Path()).run_command(cmd).returncode == 0
     metadata_lint_update(role_directory)
 
     with change_dir_to(role_directory):
@@ -48,11 +49,11 @@ def test_ec2_command_init_scenario(temp_dir):
             "--role_name=test-init",
             "--driver-name=ec2",
         ]
-        assert run_command(cmd).returncode == 0
+        assert get_app(Path()).run_command(cmd).returncode == 0
 
         assert os.path.isdir(scenario_directory)
         os.unlink(os.path.join(scenario_directory, "create.yml"))
         os.unlink(os.path.join(scenario_directory, "destroy.yml"))
 
         cmd = ["molecule", "test", "-s", "test-scenario"]
-        assert run_command(cmd).returncode == 0
+        assert get_app(Path()).run_command(cmd).returncode == 0

--- a/test/gce/functional/test_func.py
+++ b/test/gce/functional/test_func.py
@@ -20,12 +20,13 @@
 #  DEALINGS IN THE SOFTWARE.
 
 import os
+from pathlib import Path
 
 import pytest
 
 from conftest import change_dir_to, metadata_lint_update
 from molecule import logger
-from molecule.util import run_command
+from molecule.app import get_app
 
 LOG = logger.get_logger(__name__)
 driver_name = __name__.split(".")[0].split("_")[-1]
@@ -36,7 +37,7 @@ def test_gce_command_init_scenario(temp_dir):
     """Test init scenario with driver."""
     role_directory = os.path.join(temp_dir.strpath, "test-init")
     cmd = ["molecule", "init", "role", "test-init"]
-    assert run_command(cmd).returncode == 0
+    assert get_app(Path()).run_command(cmd).returncode == 0
     metadata_lint_update(role_directory)
 
     with change_dir_to(role_directory):
@@ -52,11 +53,11 @@ def test_gce_command_init_scenario(temp_dir):
             "--driver-name",
             driver_name,
         ]
-        assert run_command(cmd).returncode == 0
+        assert get_app(Path()).run_command(cmd).returncode == 0
 
         assert os.path.isdir(scenario_directory)
         os.unlink(os.path.join(scenario_directory, "create.yml"))
         os.unlink(os.path.join(scenario_directory, "destroy.yml"))
 
         cmd = ["molecule", "test", "-s", "test-scenario"]
-        assert run_command(cmd).returncode == 0
+        assert get_app(Path()).run_command(cmd).returncode == 0

--- a/test/openstack/test_func.py
+++ b/test/openstack/test_func.py
@@ -4,13 +4,14 @@ import os
 import pathlib
 import shutil
 import subprocess
+from pathlib import Path
 
 import pytest
 
 import openstack
 from conftest import change_dir_to
 from molecule import logger
-from molecule.util import run_command
+from molecule.app import get_app
 
 LOG = logger.get_logger(__name__)
 
@@ -53,7 +54,7 @@ def test_openstack_init_and_test_scenario(tmp_path: pathlib.Path, DRIVER: str) -
             "--driver-name",
             DRIVER,
         ]
-        result = run_command(cmd)
+        result = get_app(tmp_path).run_command(cmd)
         assert result.returncode == 0
 
         assert scenario_directory.exists()
@@ -71,7 +72,7 @@ def test_openstack_init_and_test_scenario(tmp_path: pathlib.Path, DRIVER: str) -
         shutil.copyfile(testconf, confpath)
 
         cmd = ["molecule", "--debug", "test", "-s", scenario_name]
-        result = run_command(cmd)
+        result = get_app(tmp_path).run_command(cmd)
         assert result.returncode == 0
 
 
@@ -86,5 +87,5 @@ def test_specific_scenarios(temp_dir, scenario) -> None:
 
     with change_dir_to(scenario_directory):
         cmd = ["molecule", "test", "--scenario-name", scenario]
-        result = run_command(cmd)
+        result = get_app(Path()).run_command(cmd)
         assert result.returncode == 0

--- a/test/podman/test_func.py
+++ b/test/podman/test_func.py
@@ -3,10 +3,11 @@
 import os
 import pathlib
 import subprocess
+from pathlib import Path
 
 from conftest import change_dir_to
 from molecule import logger
-from molecule.util import run_command
+from molecule.app import get_app
 from molecule_plugins.podman import __file__ as module_file
 
 LOG = logger.get_logger(__name__)
@@ -35,27 +36,33 @@ def test_podman_command_init_scenario(tmp_path: pathlib.Path):
             "--driver-name",
             "podman",
         ]
-        result = run_command(cmd)
+        result = get_app(tmp_path).run_command(cmd)
         assert result.returncode == 0
 
         assert scenario_directory.exists()
 
         # run molecule reset as this may clean some leftovers from other
         # test runs and also ensure that reset works.
-        result = run_command(["molecule", "reset"])  # default sceanario
+        result = get_app(tmp_path).run_command(
+            ["molecule", "reset"]
+        )  # default sceanario
         assert result.returncode == 0
 
-        result = run_command(["molecule", "reset", "-s", scenario_name])
+        result = get_app(tmp_path).run_command(
+            ["molecule", "reset", "-s", scenario_name]
+        )
         assert result.returncode == 0
 
         cmd = ["molecule", "--debug", "test", "-s", scenario_name]
-        result = run_command(cmd)
+        result = get_app(tmp_path).run_command(cmd)
         assert result.returncode == 0
 
 
 def test_sample() -> None:
     """Runs the sample scenario present at the repository root."""
-    result = run_command(["molecule", "test", "-s", "test-podman"])  # default sceanario
+    result = get_app(Path()).run_command(
+        ["molecule", "test", "-s", "test-podman"]
+    )  # default sceanario
     assert result.returncode == 0
 
 


### PR DESCRIPTION
From https://github.com/ansible/molecule/pull/4359 `util.run_command` should now replaced with `app.run_command`.

Fixes https://github.com/ansible/molecule/issues/4372