### PR TITLE
.github/workflows/release.yml: Fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Switch to using Python 3.10 by default
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install tox
         run: >-


### PR DESCRIPTION
When #294, I didn't notice that the python version was not inside quotes, leading to python version being parsed as 3.1 and not 3.10. Breaking the release workflow.
Add missing quotes.