### PR TITLE
security: hide service account content from the logs for gce driver

### DIFF
--- a/test/gce/scenarios/linux/tasks/create_linux_instance.yml
+++ b/test/gce/scenarios/linux/tasks/create_linux_instance.yml
@@ -56,3 +56,6 @@
     search_regex: SSH
     delay: 10
   loop: "{{ server.results }}"
+  loop_control:
+    label: "{{ item.name }}"
+


### PR DESCRIPTION
In GCE driver, when instance is created using environment variable `GCP_SERVICE_ACCOUNT_CONTENTS` (which is json with account metadata _AND_ private key for the service account), GCE module returns it back into 'register' (may be, it's a security bug from them too).

GCE driver prints those return data on log in plain text, including private key.

Below there is a screenshot of actual leak (leaked key is shown in red, key is rotated before filing this bug report.

![image](https://github.com/user-attachments/assets/7c787207-e96f-463b-901c-dc69a934782a)
