### PR TITLE
Fix CI with newest molecule

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,7 +9,6 @@ import pytest
 
 from molecule import config, logger
 from molecule.app import get_app
-from molecule.scenario import ephemeral_directory
 
 LOG = logger.get_logger(__name__)
 
@@ -77,16 +76,6 @@ def molecule_file():
 @pytest.helpers.register
 def get_molecule_file(path):
     return config.molecule_file(path)
-
-
-@pytest.helpers.register
-def molecule_ephemeral_directory(_fixture_uuid):
-    project_directory = f"test-project-{_fixture_uuid}"
-    scenario_name = "test-instance"
-
-    return ephemeral_directory(
-        os.path.join("molecule_test", project_directory, scenario_name),
-    )
 
 
 def metadata_lint_update(role_directory: str) -> None:

--- a/test/vagrant-plugin/functional/test_func.py
+++ b/test/vagrant-plugin/functional/test_func.py
@@ -30,7 +30,6 @@ import vagrant
 from conftest import change_dir_to
 from molecule import logger, util
 from molecule.app import get_app
-from molecule.scenario import ephemeral_directory
 
 LOG = logger.get_logger(__name__)
 
@@ -141,16 +140,17 @@ def test_multi_node(temp_dir):
         "scenarios",
     )
 
+    molecule_eph_directory = os.path.join(temp_dir, "ephemeral")
+    env = os.environ
+    env["MOLECULE_EPHEMERAL_DIRECTORY"] = molecule_eph_directory
+
     with change_dir_to(scenario_directory):
         cmd = ["molecule", "test", "--scenario-name", "multi-node"]
-        result = get_app(Path()).run_command(cmd)
+        result = get_app(Path()).run_command(cmd, env=env)
         assert result.returncode == 0
 
-    molecule_eph_directory = ephemeral_directory()
     vagrantfile = os.path.join(
         molecule_eph_directory,
-        "scenarios",
-        "multi-node",
         "Vagrantfile",
     )
     with open(vagrantfile) as f:


### PR DESCRIPTION
Get rid of the use of  molecule ephemeral_directory() as it's gone. The most affected test was the vagrant one, as it's checking the generated Vagrantfile. Set the environment variable for the ephemeral directory in this case, so that we know for sure the path of the ephemeral directory.