### PR TITLE
fix: ansible truthy handling

### DIFF
--- a/src/molecule_plugins/docker/playbooks/create.yml
+++ b/src/molecule_plugins/docker/playbooks/create.yml
@@ -207,7 +207,7 @@
       ansible.builtin.async_status:
         jid: "{{ item.ansible_job_id }}"
       register: docker_jobs
-      until: docker_jobs.finished is truthy
+      until: docker_jobs is finished
       retries: 300
       with_items: "{{ server.results }}"
       loop_control:

--- a/src/molecule_plugins/docker/playbooks/create.yml
+++ b/src/molecule_plugins/docker/playbooks/create.yml
@@ -13,7 +13,7 @@
     - name: Set async_dir for HOME env
       ansible.builtin.set_fact:
         ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
-      when: (lookup('env', 'HOME'))
+      when: lookup('env', 'HOME') is truthy
 
     - name: Log into a Docker registry
       community.docker.docker_login:
@@ -31,7 +31,7 @@
         label: "{{ item.registry.url | default(item.name) }}"
       when:
         - item.registry is defined
-        - item.registry.url is defined and item.registry.url
+        - item.registry.url is truthy
         - item.registry.credentials is defined
         - item.registry.credentials.username is defined
       no_log: true
@@ -207,7 +207,7 @@
       ansible.builtin.async_status:
         jid: "{{ item.ansible_job_id }}"
       register: docker_jobs
-      until: docker_jobs.finished
+      until: docker_jobs.finished is truthy
       retries: 300
       with_items: "{{ server.results }}"
       loop_control:

--- a/src/molecule_plugins/docker/playbooks/destroy.yml
+++ b/src/molecule_plugins/docker/playbooks/destroy.yml
@@ -38,7 +38,7 @@
       ansible.builtin.async_status:
         jid: "{{ item.ansible_job_id }}"
       register: docker_jobs
-      until: docker_jobs.finished is truthy
+      until: docker_jobs is finished
       retries: 300
       loop: "{{ server.results }}"
       loop_control:

--- a/src/molecule_plugins/docker/playbooks/destroy.yml
+++ b/src/molecule_plugins/docker/playbooks/destroy.yml
@@ -10,7 +10,7 @@
     - name: Set async_dir for HOME env
       ansible.builtin.set_fact:
         ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
-      when: (lookup('env', 'HOME'))
+      when: lookup('env', 'HOME') is truthy
 
     - name: Destroy molecule instance(s)
       community.docker.docker_container:
@@ -38,7 +38,7 @@
       ansible.builtin.async_status:
         jid: "{{ item.ansible_job_id }}"
       register: docker_jobs
-      until: docker_jobs.finished
+      until: docker_jobs.finished is truthy
       retries: 300
       loop: "{{ server.results }}"
       loop_control:

--- a/src/molecule_plugins/podman/playbooks/create.yml
+++ b/src/molecule_plugins/podman/playbooks/create.yml
@@ -184,7 +184,7 @@
       ansible.builtin.async_status:
         jid: "{{ item.ansible_job_id }}"
       register: podman_jobs
-      until: podman_jobs.finished is truthy
+      until: podman_jobs is finished
       retries: 300
       with_items: "{{ server.results }}"
       loop_control:

--- a/src/molecule_plugins/podman/playbooks/create.yml
+++ b/src/molecule_plugins/podman/playbooks/create.yml
@@ -4,9 +4,9 @@
   connection: local
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
-  become: "{{ not (item.rootless|default(true)) }}"
+  become: "{{ not (item.rootless | default(true)) }}"
   vars:
-    podman_exec: "{{ lookup('env','MOLECULE_PODMAN_EXECUTABLE')|default('podman',true) }}"
+    podman_exec: "{{ lookup('env','MOLECULE_PODMAN_EXECUTABLE') | default('podman', true) }}"
   tasks:
     - name: Log into a container registry
       containers.podman.podman_login:
@@ -26,7 +26,7 @@
           {{ item.registry.credentials.username | default('None specified') }}"
       when:
         - item.registry is defined
-        - item.registry.url is defined and item.registry.url
+        - item.registry.url is truthy
         - item.registry.credentials is defined
         - item.registry.credentials.username is defined
       changed_when: false
@@ -184,7 +184,7 @@
       ansible.builtin.async_status:
         jid: "{{ item.ansible_job_id }}"
       register: podman_jobs
-      until: podman_jobs.finished
+      until: podman_jobs.finished is truthy
       retries: 300
       with_items: "{{ server.results }}"
       loop_control:

--- a/src/molecule_plugins/podman/playbooks/destroy.yml
+++ b/src/molecule_plugins/podman/playbooks/destroy.yml
@@ -4,9 +4,9 @@
   connection: local
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
-  become: "{{ not (item.rootless|default(true)) }}"
+  become: "{{ not (item.rootless | default(true)) }}"
   vars:
-    podman_exec: "{{ lookup('env','MOLECULE_PODMAN_EXECUTABLE')|default('podman',true) }}"
+    podman_exec: "{{ lookup('env','MOLECULE_PODMAN_EXECUTABLE') | default('podman',true) }}"
   tasks:
     - name: Destroy molecule instance(s)
       ansible.builtin.shell: "{{ podman_exec }} container exists {{ item.name }} && {{ podman_exec }} rm -f {{ item.name }} || true"
@@ -21,7 +21,7 @@
       ansible.builtin.async_status:
         jid: "{{ item.ansible_job_id }}"
       register: podman_jobs
-      until: podman_jobs.finished
+      until: podman_jobs.finished is truthy
       retries: 300
       with_items: "{{ server.results }}"
 

--- a/src/molecule_plugins/podman/playbooks/destroy.yml
+++ b/src/molecule_plugins/podman/playbooks/destroy.yml
@@ -21,7 +21,7 @@
       ansible.builtin.async_status:
         jid: "{{ item.ansible_job_id }}"
       register: podman_jobs
-      until: podman_jobs.finished is truthy
+      until: podman_jobs is finished
       retries: 300
       with_items: "{{ server.results }}"
 


### PR DESCRIPTION
With the new Ansible version 2.19, something changes in handling with true/false values, which is why the molecule tests fail.

https://github.com/ansible-collections/community.grafana/actions/runs/14622246579/job/41025024595?pr=419
```
  TASK [Set async_dir for HOME env] **********************************************
  [ERROR]: Task failed: Conditional result was '/home/runner' of type 'str', which evaluates to True. Conditionals must have a boolean result.
  
  Task failed.
  Origin: /opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/molecule_plugins/docker/playbooks/destroy.yml:10:7
  
   8     - always
   9   tasks:
  10     - name: Set async_dir for HOME env
           ^ column 7
  
  <<< caused by >>>
  
  Conditional result was '/home/runner' of type 'str', which evaluates to True. Conditionals must have a boolean result.
  Origin: /opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/molecule_plugins/docker/playbooks/destroy.yml:13:13
  
  11       ansible.builtin.set_fact:
  12         ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async/"
  13       when: (lookup('env', 'HOME'))
                 ^ column 13
  
  Broken conditionals can be temporarily allowed with the `ALLOW_BROKEN_CONDITIONALS` configuration option.
  
  fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task failed: Conditional result was '/home/runner' of type 'str', which evaluates to True. Conditionals must have a boolean result."}
```

Fixes #311 