### PR TITLE
use fixtures to create ephemeral directory for vagrant

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,9 +9,14 @@ import pytest
 
 from molecule import config, logger
 from molecule.app import get_app
-from molecule.scenario import ephemeral_directory
 
 LOG = logger.get_logger(__name__)
+
+
+@pytest.fixture(scope="session")
+def ephemeral_directory(tmp_path_factory):
+    """Create a session-scoped ephemeral directory for molecule tests."""
+    return tmp_path_factory.mktemp("molecule_test")
 
 
 @pytest.helpers.register
@@ -80,13 +85,11 @@ def get_molecule_file(path):
 
 
 @pytest.helpers.register
-def molecule_ephemeral_directory(_fixture_uuid):
+def molecule_ephemeral_directory(_fixture_uuid, ephemeral_directory):
     project_directory = f"test-project-{_fixture_uuid}"
     scenario_name = "test-instance"
 
-    return ephemeral_directory(
-        os.path.join("molecule_test", project_directory, scenario_name),
-    )
+    return os.path.join(ephemeral_directory, project_directory, scenario_name)
 
 
 def metadata_lint_update(role_directory: str) -> None:

--- a/test/vagrant-plugin/functional/test_func.py
+++ b/test/vagrant-plugin/functional/test_func.py
@@ -30,7 +30,6 @@ import vagrant
 from conftest import change_dir_to
 from molecule import logger, util
 from molecule.app import get_app
-from molecule.scenario import ephemeral_directory
 
 LOG = logger.get_logger(__name__)
 
@@ -134,7 +133,7 @@ def test_vagrant_root(temp_dir, scenario):
     not is_vagrant_supported(),
     reason="vagrant not supported on this machine",
 )
-def test_multi_node(temp_dir):
+def test_multi_node(temp_dir, ephemeral_directory):
     scenario_directory = os.path.join(
         os.path.dirname(util.abs_path(__file__)),
         os.path.pardir,
@@ -146,9 +145,8 @@ def test_multi_node(temp_dir):
         result = get_app(Path()).run_command(cmd)
         assert result.returncode == 0
 
-    molecule_eph_directory = ephemeral_directory()
     vagrantfile = os.path.join(
-        molecule_eph_directory,
+        ephemeral_directory,
         "scenarios",
         "multi-node",
         "Vagrantfile",


### PR DESCRIPTION
Due to a previous commit to molecule removes the ephemeral_directory method from the exports in scenario.py which makes it unavailable for use in molecule-plugin pytests:
<https://github.com/ansible/molecule/commit/45db06d26f542685b666361429990b751d3f1469>

This PR uses a pytest fixture to create an ephemeral directory instead