### PR TITLE
Fix podman plugin on latest molecule version

### DIFF
--- a/src/molecule_plugins/podman/playbooks/create.yml
+++ b/src/molecule_plugins/podman/playbooks/create.yml
@@ -26,7 +26,7 @@
           {{ item.registry.credentials.username | default('None specified') }}"
       when:
         - item.registry is defined
-        - item.registry.url is defined and item.registry.url
+        - item.registry.url is defined and (item.registry.url | length > 0)
         - item.registry.credentials is defined
         - item.registry.credentials.username is defined
       changed_when: false


### PR DESCRIPTION
On the latest version of molecule (25.7) and molecule-plugins (25.3) there appears to be in a bug in the code responsible for checking if a registry was defined. When a registry is set, the conditional `item.registry.url` fails -- it is supposed to return a boolean, but is a string.

See here for an example of the error:

https://github.com/UtrechtUniversity/researchcloud-items/actions/runs/16621822691/job/47027841963?pr=297#step:8:278