### PR TITLE
Openstack: add support for multiple networks via nics

### DIFF
--- a/src/molecule_plugins/openstack/playbooks/create.yml
+++ b/src/molecule_plugins/openstack/playbooks/create.yml
@@ -107,14 +107,27 @@
         boot_from_volume: "{{ true if item.volume is defined and item.volume.size else false }}"
         terminate_volume: "{{ true if item.volume is defined and item.volume.size else false }}"
         volume_size: "{{ item.volume.size if item.volume is defined and item.volume.size else omit }}"
-        network: >-
-          {{
-            'molecule-test-' + item.network.name + '-' + uuid
-            if item.network is defined and item.network.name and (item.network.create | default(true))
-            else item.network.name
-            if item.network is defined and item.network.name and not (item.network.create | default(true))
-            else 'public'
-          }}
+        nics: >-
+          {%- set nets = [] -%}
+          {%- if item.networks is defined -%}
+            {%- set nets = item.networks -%}
+          {%- elif item.network is defined -%}
+            {%- set nets = [item.network] -%}
+          {%- endif -%}
+
+          {%- if nets | length == 0 -%}
+            [{'net-name': 'public'}]
+          {%- else -%}
+            [
+              {%- for net in nets -%}
+                {%- if net.create is not defined or net.create -%}
+                  {'net-name': 'molecule-test-{{ net.name }}-{{ uuid }}'}{% if not loop.last %}, {% endif %}
+                {%- else -%}
+                  {'net-name': '{{ net.name }}'}{% if not loop.last %}, {% endif %}
+                {%- endif -%}
+              {%- endfor -%}
+            ]
+          {%- endif -%}
         security_groups:
           - >-
             {{


### PR DESCRIPTION
This PR updates the OpenStack Molecule plugin to allow attaching multiple networks to instances by using the nics parameter instead of the single network parameter. It maintains backward compatibility with the existing network key while enabling more flexible network configurations.