### PR TITLE
fix: openstack driver private address retrieval when auto_ip is False (ansible 2.19)

### DIFF
--- a/src/molecule_plugins/openstack/playbooks/tasks/server_addr.yml
+++ b/src/molecule_plugins/openstack/playbooks/tasks/server_addr.yml
@@ -17,7 +17,7 @@
 - name: Set to first addr if no floating
   ansible.builtin.set_fact:
     address: "{{ item.addresses[item.metadata.get('network', 'public')][0].addr }}"
-  when: address == ""
+  when: not address
 
 - name: Populate instance config dict
   ansible.builtin.set_fact:


### PR DESCRIPTION
In ansible 2.19, the template for retrieving the public(floating) address of a molecule instance returns a NoneType value, which in turn evaluates to False when compared to "" , which cause the private address of the instance to never get picked up as fallback. This commit changes the condition to not address | bool which in both case will evaluate to True if the retrieval of the public ip failed.

This will fix #325 