### PR TITLE
feat(podman): Add driver schema

### DIFF
--- a/src/molecule_plugins/podman/driver.py
+++ b/src/molecule_plugins/podman/driver.py
@@ -19,6 +19,8 @@
 #  DEALINGS IN THE SOFTWARE.
 """Podman Driver Module."""
 
+from __future__ import annotations
+
 import os
 import warnings
 from pathlib import Path
@@ -261,3 +263,10 @@ class Podman(Driver):
                 "--filter=label=owner=molecule",
             ]
         )
+
+    def schema_file(self) -> str | None:
+        """Return the path to the driver's JSON schema file."""
+        p = Path(self._path, "schema", "driver.json")
+        if p.is_file():
+            return str(p)
+        return None

--- a/src/molecule_plugins/podman/schema/driver.json
+++ b/src/molecule_plugins/podman/schema/driver.json
@@ -1,0 +1,336 @@
+{
+  "$defs": {
+    "MoleculeDriverModel": {
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "enum": ["podman", "containers"],
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": ["name"],
+      "title": "MoleculeDriverModel",
+      "type": "object"
+    },
+    "MoleculePlatformModel": {
+      "additionalProperties": false,
+      "properties": {
+        "buildargs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arguments that control image build.",
+          "examples": [{ "http_proxy": "http://proxy.example.com:8080/" }],
+          "title": "Build Arguments",
+          "type": "object"
+        },
+        "capabilities": {
+          "description": "List of capabilities to add to the container.",
+          "examples": ["CAP_NET_ADMIN", "CAP_SYS_ADMIN", "CAP_NET_RAW"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Capabilities",
+          "type": "array"
+        },
+        "cert_path": {
+          "description": "Use certificates at path (*.crt, *.cert, *.key) to connect to the registry.",
+          "title": "Cert Path",
+          "type": "string"
+        },
+        "cgroup_manager": {
+          "description": "The CGroup manager to use for container cgroups. Supported values are cgroupfs or systemd.",
+          "enum": ["cgroupfs", "systemd"],
+          "examples": ["cgroupfs", "systemd"],
+          "title": "Cgroup Manager",
+          "type": "string"
+        },
+        "command": {
+          "description": "Override command of container.",
+          "examples": ["/sbin/init", ["/bin/bash", "-lc", "echo hello"]],
+          "items": {
+            "type": "string"
+          },
+          "title": "Command",
+          "type": ["string", "array"]
+        },
+        "detach": {
+          "description": "Run container in detach mode.",
+          "title": "Detach",
+          "type": "boolean"
+        },
+        "devices": {
+          "description": "List of device mappings to add a host device to the container. The format is <device-on-host>[:<device-on-container>][:<permissions>].",
+          "examples": ["/dev/sdc:/dev/xvdc:rwm", "/dev/sr0:/dev/xvdc:ro"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Devices",
+          "type": "array"
+        },
+        "dns_servers": {
+          "description": "List of DNS servers for the container to use.",
+          "examples": ["8.8.8.8", "1.1.1.1"],
+          "items": {
+            "type": "string"
+          },
+          "title": "DNS Servers",
+          "type": "array"
+        },
+        "dockerfile": {
+          "description": "Path to a Dockerfile.j2 file used to build the image.",
+          "title": "Dockerfile",
+          "type": "string"
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Set environment variables. This option allows you to specify arbitrary environment variables that are available for the process that will be launched inside of the container.",
+          "examples": [{ "BAZ": "qux", "FOO": "bar" }],
+          "title": "Environment",
+          "type": "object"
+        },
+        "etc_hosts": {
+          "description": "Dict of host-to-IP mappings, where each host name is a key in the dictionary. Each host name will be added to the container's ``/etc/hosts`` file.",
+          "examples": [{ "host1.example.com": "10.3.1.5" }],
+          "patternProperties": {
+            "^.*": {
+              "type": "string"
+            }
+          },
+          "title": "etc hosts",
+          "type": "object"
+        },
+        "exposed_ports": {
+          "description": "List of ports to expose on the container.",
+          "examples": ["22/tcp", "5000"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Exposed Ports",
+          "type": "array"
+        },
+        "extra_opts": {
+          "description": "Any additional command options you want to pass to podman command itself, for example --log-level=debug or --syslog. This is NOT command to run in container, but rather options for podman itself",
+          "examples": ["--log-level=debug", "--syslog", "--memory=128m"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Extra Opts",
+          "type": "array"
+        },
+        "groups": {
+          "examples": ["webserver", "db"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Groups",
+          "type": "array"
+        },
+        "hostname": {
+          "description": "Container host name. Sets the container host name that is available inside the container.",
+          "title": "Hostname",
+          "type": "string"
+        },
+        "image": {
+          "description": "Repository path (or image name) and tag used to create the container. If an image is not found, the image will be pulled from the registry. If no tag is included, latest will be used.",
+          "title": "Image",
+          "type": "string"
+        },
+        "ip": {
+          "description": "Static IP address to assign to the container.",
+          "title": "IP",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the container",
+          "title": "Name",
+          "type": "string"
+        },
+        "network": {
+          "description": "Set the Network mode for the container. * \"bridge\" create a network stack on the default bridge * \"none\" no networking * \"container:<name|id>\" reuse another container's network stack * \"host\" use the podman host network stack. * \"<network-name>|<network-id>\" connect to a user-defined network * \"ns:<path>\" path to a network namespace to join * \"slirp4netns\" use slirp4netns to create a user network stack.",
+          "examples": [
+            "bridge",
+            "none",
+            "host",
+            "slirp4netns",
+            "container:<name|id>",
+            "<network-name>|<network-id>",
+            "ns:<path>"
+          ],
+          "title": "Network",
+          "type": "string"
+        },
+        "override_command": {
+          "description": "Whether or not to override the default command set by the container image.",
+          "title": "Override Command",
+          "type": "boolean"
+        },
+        "pid_mode": {
+          "description": "Set the PID mode for the container.",
+          "title": "PID Mode",
+          "type": "string"
+        },
+        "pre_build_image": {
+          "description": "Build the image before creating the container.",
+          "title": "Pre Build Image",
+          "type": "boolean"
+        },
+        "privileged": {
+          "description": "Give extended privileges to the container.",
+          "title": "Privileged",
+          "type": "boolean"
+        },
+        "published_ports": {
+          "description": "Publish a container's port, or range of ports, to the host. Format - \"ip:hostPort:containerPort\" | \"ip::containerPort\" | \"hostPort:containerPort\" | \"containerPort\". In case of only containerPort is set, the hostPort will chosen randomly by Podman.",
+          "examples": ["8080:80", "0.0.0.0:8053:53/udp"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Published Ports",
+          "type": "array"
+        },
+        "pull": {
+          "description": "Whether or not to pull the image.",
+          "title": "Pull",
+          "type": "boolean"
+        },
+        "registry": {
+          "additionalProperties": false,
+          "description": "Registry configuration.",
+          "properties": {
+            "credentials": {
+              "additionalProperties": false,
+              "description": "Credentials for the registry server.",
+              "properties": {
+                "password": {
+                  "description": "Password for the registry server.",
+                  "title": "Password",
+                  "type": "string"
+                },
+                "username": {
+                  "description": "Username for the registry server.",
+                  "title": "Username",
+                  "type": "string"
+                }
+              },
+              "required": ["username", "password"],
+              "title": "Credentials",
+              "type": "object"
+            },
+            "url": {
+              "description": "Registry server URL.",
+              "format": "uri",
+              "title": "Url",
+              "type": "string"
+            }
+          },
+          "title": "Registry",
+          "type": "object"
+        },
+        "restart_policy": {
+          "description": "Restart policy to follow when containers exit. Valid values are * no - Do not restart containers on exit. (This needs to be quoted, otherwise it will parse to false) * on-failure - Restart containers when they exit with a non-0 exit code, retrying indefinitely or until the optional restart_retries count is hit * always - Restart containers when they exit, regardless of status, retrying indefinitely",
+          "enum": ["no", "on-failure", "always"],
+          "title": "Restart Policy",
+          "type": "string"
+        },
+        "restart_retries": {
+          "description": "The number of times to retry restarting a container when the restart_policy is set to on-failure. This option is ignored when restart_policy is set to no or always.",
+          "minimum": 0,
+          "title": "Restart Retries",
+          "type": "integer"
+        },
+        "rootless": {
+          "description": "Whether to run Podman commands in rootless mode (disables become).",
+          "title": "Rootless",
+          "type": "boolean"
+        },
+        "security_opts": {
+          "description": "Security Options.",
+          "examples": ["seccomp=unconfined"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Security Options",
+          "type": "array"
+        },
+        "storage_driver": {
+          "description": "Specify a storage driver to use.",
+          "examples": ["overlay", "vfs", "fuse-overlayfs"],
+          "title": "Storage Driver",
+          "type": "string"
+        },
+        "storage_opt": {
+          "description": "Specify a storage driver option.",
+          "examples": ["overlay.mount_program=/usr/bin/fuse-overlayfs"],
+          "title": "Storage Options",
+          "type": "string"
+        },
+        "systemd": {
+          "description": "Run container in systemd mode. Valid values are * true - enables systemd mode only when the command executed inside the container is systemd, /usr/sbin/init, /sbin/init or /usr/local/sbin/init. * false - disables systemd mode. * always - enforces the systemd mode to be enabled.",
+          "enum": ["true", "false", "always"],
+          "title": "Systemd",
+          "type": "string"
+        },
+        "tls_verify": {
+          "description": "Require HTTPS and verify certificates when contacting registries. If explicitly set to true, then TLS verification will be used. If set to false, then TLS verification will not be used.",
+          "title": "TLS Verify",
+          "type": "boolean"
+        },
+        "tmpfs": {
+          "description": "Create a tmpfs mount. For example tmpfs \"/tmp\" \"rw,size=787448k,mode=1777\"",
+          "examples": ["/tmp", "rw,size=787448k,mode=1777"],
+          "items": {
+            "type": "string"
+          },
+          "title": "tmpfs",
+          "type": "array"
+        },
+        "tty": {
+          "description": "Allocate a pseudo-TTY.",
+          "title": "TTY",
+          "type": "boolean"
+        },
+        "ulimits": {
+          "description": "Ulimit options.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Ulimits",
+          "type": "array"
+        },
+        "volumes": {
+          "description": "Create a bind mount. If you specify, volume /HOST-DIR:/CONTAINER-DIR, podman bind mounts /HOST-DIR in the host to /CONTAINER-DIR in the podman container.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Volumes",
+          "type": "array"
+        }
+      },
+      "required": ["name"],
+      "title": "MoleculePlatformModel",
+      "type": "object"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/ansible-community/molecule-plugins/main/src/molecule_plugins/podman/schema/driver.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "examples": ["molecule/*/molecule.yml"],
+  "properties": {
+    "driver": {
+      "$ref": "#/$defs/MoleculeDriverModel"
+    },
+    "platforms": {
+      "items": {
+        "$ref": "#/$defs/MoleculePlatformModel"
+      },
+      "title": "Platforms",
+      "type": "array"
+    }
+  },
+  "required": ["driver"],
+  "title": "Molecule Podman Driver Schema",
+  "type": "object"
+}

--- a/test/podman/test_driver.py
+++ b/test/podman/test_driver.py
@@ -1,12 +1,125 @@
 """Unit tests."""
 
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError, validate
+
 from molecule import api
 from molecule_plugins.podman.driver import Podman
 
 
-def test_podman_driver_is_detected():
+def test_podman_driver_is_detected(driver_name):
     """Asserts that molecule recognizes the driver."""
-    assert any(str(d) == "podman" for d in api.drivers())
+    assert driver_name in [str(d) for d in api.drivers()]
+
+
+def test_podman_driver_provides_schema(driver_name):
+    """Asserts that the podman driver provides a JSON schema file."""
+    driver = api.drivers()[driver_name]
+    schema_file = driver.schema_file()
+
+    assert schema_file is not None
+    assert Path(schema_file).is_file()
+    assert schema_file.endswith(driver_name + "/schema/driver.json")
+
+
+def test_podman_driver_schema_is_valid(driver_name):
+    """Asserts that the podman driver schema is a valid JSON Schema."""
+    schema_file = api.drivers()[driver_name].schema_file()
+    schema = json.loads(Path(schema_file).read_text())
+    Draft202012Validator.check_schema(schema)
+
+
+@pytest.mark.parametrize(
+    ("config", "valid"),
+    [
+        # Minimal valid configuration
+        (
+            {
+                "driver": {"name": "podman"},
+                "platforms": [{"name": "instance", "image": "image:tag"}],
+            },
+            True,
+        ),
+        # Comprehensive configuration exercising all documented options
+        (
+            {
+                "driver": {"name": "podman"},
+                "platforms": [
+                    {
+                        "buildargs": {"http_proxy": "http://proxy:8080/"},
+                        "capabilities": ["SYS_ADMIN"],
+                        "cert_path": "/foo/bar/cert.pem",
+                        "cgroup_manager": "systemd",
+                        "command": "sleep infinity",
+                        "detach": True,
+                        "devices": ["/dev/fuse:/dev/fuse:rwm"],
+                        "dns_servers": ["8.8.8.8"],
+                        "dockerfile": "Dockerfile.j2",
+                        "env": {"FOO": "bar"},
+                        "etc_hosts": {"host1.example.com": "10.3.1.5"},
+                        "exposed_ports": ["53/udp"],
+                        "extra_opts": ["--log-level=debug"],
+                        "groups": ["webserver", "db"],
+                        "hostname": "instance",
+                        "image": "image:tag",
+                        "ip": "10.10.99.10",
+                        "name": "instance",
+                        "network": "host",
+                        "override_command": True,
+                        "pid_mode": "host",
+                        "pre_build_image": False,
+                        "privileged": True,
+                        "published_ports": ["0.0.0.0:8053:53/udp"],
+                        "pull": True,
+                        "registry": {
+                            "credentials": {"password": "p", "username": "u"},
+                            "url": "registry.example.com",
+                        },
+                        "restart_policy": "on-failure",
+                        "restart_retries": 1,
+                        "rootless": True,
+                        "security_opts": ["seccomp=unconfined"],
+                        "storage_opt": "overlay.mount_program=/usr/bin/fuse-overlayfs",
+                        "systemd": "false",
+                        "tls_verify": True,
+                        "tmpfs": ["/tmp", "rw,size=787448k,mode=1777"],
+                        "tty": True,
+                        "ulimits": ["nofile:262144:262144"],
+                        "volumes": ["/sys/fs/cgroup:/sys/fs/cgroup:ro"],
+                    }
+                ],
+            },
+            True,
+        ),
+        # Docker-only options must be rejected
+        (
+            {
+                "driver": {"name": "podman"},
+                "platforms": [
+                    {
+                        "name": "instance",
+                        "image": "image:tag",
+                        "docker_networks": [{"name": "foo"}],
+                        "systemd": "true",
+                    }
+                ],
+            },
+            False,
+        ),
+    ],
+)
+def test_podman_driver_schema_validation(config, valid):
+    """Asserts that the podman driver schema accepts/rejects configs correctly."""
+    schema_file = api.drivers()["podman"].schema_file()
+    schema = json.loads(Path(schema_file).read_text())
+    if valid:
+        validate(instance=config, schema=schema)
+    else:
+        with pytest.raises(ValidationError):
+            validate(instance=config, schema=schema)
 
 
 def test_driver_initializes_without_podman_executable(monkeypatch):


### PR DESCRIPTION
Currently, when running molecule with the podman driver, we get the following message:

```
WARNING  Driver podman does not provide a schema.
```

So, let's add a schema 🎉 

Fixes #304