### PR TITLE
bug: align required collections between drivers `podman` and `containers`

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -6,6 +6,7 @@ collections:
   - name: community.docker
     version: ">=3.10.2" # keep in sync with src/molecule_plugins/docker/driver.py and src/molecule_plugins/containers/driver.py
   - name: containers.podman
+    version: ">=1.8.1" # keep in sync with src/molecule_plugins/podman/driver.py and src/molecule_plugins/containers/driver.py
   - name: azure.azcollection
     version: ">=1,<2"
   - name: community.crypto

--- a/src/molecule_plugins/containers/driver.py
+++ b/src/molecule_plugins/containers/driver.py
@@ -45,6 +45,7 @@ class Container(DriverBackend):
     @property
     def required_collections(self) -> dict[str, str]:
         """Return collections dict containing names and versions required."""
+        # keep in sync with src/molecule_plugins/docker/driver.py, src/molecule_plugins/podman/driver.py and requirements.yml
         return {
             "ansible.posix": "1.4.0",  # keep in sync with src/molecule_plugins/docker/driver.py and requirements.yml
             "community.docker": "3.10.2",  # keep in sync with src/molecule_plugins/docker/driver.py and requirements.yml

--- a/src/molecule_plugins/podman/driver.py
+++ b/src/molecule_plugins/podman/driver.py
@@ -243,7 +243,8 @@ class Podman(Driver):
     @property
     def required_collections(self) -> dict[str, str]:
         """Return collections dict containing names and versions required."""
-        return {"containers.podman": "1.7.0"}
+        # keep in sync with src/molecule_plugins/container/driver.py and requirements.yml
+        return {"containers.podman": "1.8.1"}
 
     def reset(self):
         # edge case: podman not installed, but the plugin exists and is properly initialized


### PR DESCRIPTION
The `containers` driver might use the `podman` driver as a backend and should therefore report the same required collection version of `containers.podman`.