### PR TITLE
bug: `ansible.posix` is not a required collection for the podman driver

### DIFF
--- a/src/molecule_plugins/podman/driver.py
+++ b/src/molecule_plugins/podman/driver.py
@@ -243,7 +243,7 @@ class Podman(Driver):
     @property
     def required_collections(self) -> dict[str, str]:
         """Return collections dict containing names and versions required."""
-        return {"containers.podman": "1.7.0", "ansible.posix": "1.3.0"}
+        return {"containers.podman": "1.7.0"}
 
     def reset(self):
         # edge case: podman not installed, but the plugin exists and is properly initialized


### PR DESCRIPTION
We should not report unused collections as required for a driver.