### PR TITLE
bug: align required collections between drivers `docker` and `containers`

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,10 +1,10 @@
 collections:
   - name: ansible.posix # docker
-    version: ">=1.4.0"
+    version: ">=1.4.0" # keep in sync with src/molecule_plugins/docker/driver.py and src/molecule_plugins/containers/driver.py
   - name: google.cloud
   - name: amazon.aws
   - name: community.docker
-    version: ">=3.10.2"
+    version: ">=3.10.2" # keep in sync with src/molecule_plugins/docker/driver.py and src/molecule_plugins/containers/driver.py
   - name: containers.podman
   - name: azure.azcollection
     version: ">=1,<2"

--- a/src/molecule_plugins/containers/driver.py
+++ b/src/molecule_plugins/containers/driver.py
@@ -46,7 +46,7 @@ class Container(DriverBackend):
     def required_collections(self) -> dict[str, str]:
         """Return collections dict containing names and versions required."""
         return {
-            "ansible.posix": "1.3.0",
-            "community.docker": "1.9.1",
+            "ansible.posix": "1.4.0",  # keep in sync with src/molecule_plugins/docker/driver.py and requirements.yml
+            "community.docker": "3.10.2",  # keep in sync with src/molecule_plugins/docker/driver.py and requirements.yml
             "containers.podman": "1.8.1",
         }

--- a/src/molecule_plugins/docker/driver.py
+++ b/src/molecule_plugins/docker/driver.py
@@ -275,4 +275,5 @@ class Docker(Driver):
     def required_collections(self) -> dict[str, str]:
         """Return collections dict containing names and versions required."""
         # https://galaxy.ansible.com/community/docker
+        # keep in synch with src/molecule_plugins/containers/driver.py and requirements.yml
         return {"community.docker": "3.10.2", "ansible.posix": "1.4.0"}


### PR DESCRIPTION
The `containers` driver might use the `docker` driver as a backend and should therefore report the same required collection version of `community.docker`.