### PR TITLE
feat(docker): Add driver schema

### DIFF
--- a/src/molecule_plugins/docker/driver.py
+++ b/src/molecule_plugins/docker/driver.py
@@ -19,7 +19,10 @@
 #  DEALINGS IN THE SOFTWARE.
 """Docker Driver Module."""
 
+from __future__ import annotations
+
 import os
+from pathlib import Path
 
 from molecule import logger
 from molecule.api import Driver
@@ -277,3 +280,10 @@ class Docker(Driver):
         # https://galaxy.ansible.com/community/docker
         # keep in synch with src/molecule_plugins/containers/driver.py and requirements.yml
         return {"community.docker": "3.10.2", "ansible.posix": "1.4.0"}
+
+    def schema_file(self) -> str | None:
+        """Return the path to the driver's JSON schema file."""
+        p = Path(self._path, "schema", "driver.json")
+        if p.is_file():
+            return str(p)
+        return None

--- a/src/molecule_plugins/docker/schema/driver.json
+++ b/src/molecule_plugins/docker/schema/driver.json
@@ -1,0 +1,500 @@
+{
+  "$defs": {
+    "MoleculeDriverModel": {
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "enum": ["docker", "containers"],
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": ["name"],
+      "title": "MoleculeDriverModel",
+      "type": "object"
+    },
+    "MoleculePlatformModel": {
+      "additionalProperties": false,
+      "properties": {
+        "buildargs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arguments that control image build.",
+          "examples": [{ "http_proxy": "http://proxy.example.com:8080/" }],
+          "title": "Build Arguments",
+          "type": "object"
+        },
+        "cacert_path": {
+          "description": "Use a CA certificate when performing server verification by providing the path to a CA certificate file.",
+          "title": "CA Cert Path",
+          "type": "string"
+        },
+        "cache_from": {
+          "description": "List of image names to use as cache source.",
+          "examples": ["registry.example.com/example/example:main"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Cache From",
+          "type": "array"
+        },
+        "capabilities": {
+          "description": "List of capabilities to add to the container.",
+          "examples": ["SYS_ADMIN", "NET_ADMIN"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Capabilities",
+          "type": "array"
+        },
+        "cert_path": {
+          "description": "Path to the client's TLS certificate file used to authenticate with the Docker daemon.",
+          "title": "Cert Path",
+          "type": "string"
+        },
+        "cgroupns_mode": {
+          "description": "Specify the cgroup namespace mode for the container.",
+          "enum": ["host", "private"],
+          "examples": ["host", "private"],
+          "title": "Cgroup Namespace Mode",
+          "type": "string"
+        },
+        "command": {
+          "description": "Override command of container.",
+          "examples": ["/sbin/init", "sleep infinity"],
+          "title": "Command",
+          "type": "string"
+        },
+        "command_handling": {
+          "description": "How the command and entrypoint options are handled when provided as a list.",
+          "enum": ["compatibility", "correct"],
+          "title": "Command Handling",
+          "type": "string"
+        },
+        "container_default_behavior": {
+          "description": "Various module options used to have default values in older versions of the module. This option controls what happens when the user does not specify a value for one of these options.",
+          "enum": ["compatibility", "no_defaults"],
+          "title": "Container Default Behavior",
+          "type": "string"
+        },
+        "devices": {
+          "description": "List of device mappings to add a host device to the container. The format is <device-on-host>[:<device-on-container>][:<permissions>].",
+          "examples": ["/dev/fuse:/dev/fuse:rwm"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Devices",
+          "type": "array"
+        },
+        "dns_servers": {
+          "description": "List of DNS servers for the container to use.",
+          "examples": ["8.8.8.8", "1.1.1.1"],
+          "items": {
+            "type": "string"
+          },
+          "title": "DNS Servers",
+          "type": "array"
+        },
+        "docker_host": {
+          "description": "The URL or Unix socket path used to connect to the Docker API. Defaults to the value of the DOCKER_HOST environment variable or unix:///var/run/docker.sock.",
+          "examples": ["tcp://localhost:12376", "unix:///var/run/docker.sock"],
+          "title": "Docker Host",
+          "type": "string"
+        },
+        "docker_networks": {
+          "description": "List of Docker networks to create. Each entry is passed to the docker_network module.",
+          "examples": [
+            {
+              "ipam_config": [
+                { "gateway": "10.3.1.254", "subnet": "10.3.1.0/24" }
+              ],
+              "name": "foo"
+            }
+          ],
+          "items": {
+            "additionalProperties": true,
+            "properties": {
+              "name": {
+                "description": "Name of the network.",
+                "title": "Name",
+                "type": "string"
+              }
+            },
+            "required": ["name"],
+            "title": "Docker Network",
+            "type": "object"
+          },
+          "title": "Docker Networks",
+          "type": "array"
+        },
+        "dockerfile": {
+          "description": "Path to a Dockerfile.j2 file used to build the image.",
+          "title": "Dockerfile",
+          "type": "string"
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Set environment variables. This option allows you to specify arbitrary environment variables that are available for the process that will be launched inside of the container.",
+          "examples": [{ "BAZ": "qux", "FOO": "bar" }],
+          "title": "Environment",
+          "type": "object"
+        },
+        "etc_hosts": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Dict of host-to-IP mappings, where each host name is a key in the dictionary. Each host name will be added to the container's ``/etc/hosts`` file.",
+          "examples": [{ "host1.example.com": "10.3.1.5" }],
+          "title": "etc hosts",
+          "type": "object"
+        },
+        "exposed_ports": {
+          "description": "List of ports to expose on the container.",
+          "examples": ["53/udp", "53/tcp"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Exposed Ports",
+          "type": "array"
+        },
+        "force": {
+          "description": "Whether to always rebuild the image, even if it already exists.",
+          "title": "Force Build",
+          "type": "boolean"
+        },
+        "force_kill": {
+          "description": "Use the kill signal when removing the container.",
+          "title": "Force Kill",
+          "type": "boolean"
+        },
+        "groups": {
+          "description": "List of inventory groups to add the instance to.",
+          "examples": ["webserver", "db"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Groups",
+          "type": "array"
+        },
+        "hostname": {
+          "description": "Container host name. Sets the container host name that is available inside the container.",
+          "title": "Hostname",
+          "type": "string"
+        },
+        "image": {
+          "description": "Repository path (or image name) and tag used to create the container. If an image is not found, the image will be pulled from the registry. If no tag is included, latest will be used.",
+          "title": "Image",
+          "type": "string"
+        },
+        "keep_volumes": {
+          "description": "Whether to retain anonymous volumes associated with the container when it is removed.",
+          "title": "Keep Volumes",
+          "type": "boolean"
+        },
+        "key_path": {
+          "description": "Path to the client's TLS key file used to authenticate with the Docker daemon.",
+          "title": "Key Path",
+          "type": "string"
+        },
+        "kill_signal": {
+          "description": "Signal sent to the container when killing it.",
+          "title": "Kill Signal",
+          "type": "string"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Additional labels to add to the container. The ``owner=molecule`` label is always added.",
+          "examples": [{ "app": "demo" }],
+          "title": "Labels",
+          "type": "object"
+        },
+        "links": {
+          "description": "List of container links to add to the container, in the form ``<name>:<alias>``.",
+          "examples": ["db:db"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Links",
+          "type": "array"
+        },
+        "memory": {
+          "description": "Memory limit of the container.",
+          "examples": ["512m"],
+          "title": "Memory",
+          "type": "string"
+        },
+        "memory_swap": {
+          "description": "Total memory limit of the container (memory plus swap).",
+          "examples": ["1g"],
+          "title": "Memory Swap",
+          "type": "string"
+        },
+        "mounts": {
+          "description": "List of mount dictionaries to attach to the container. Each entry is passed to the docker_container module's mounts option.",
+          "items": {
+            "type": "object"
+          },
+          "title": "Mounts",
+          "type": "array"
+        },
+        "name": {
+          "description": "Name of the container",
+          "title": "Name",
+          "type": "string"
+        },
+        "network_mode": {
+          "description": "Set the network mode for the container. Choices are ``bridge``, ``host``, ``none``, ``container:<name|id>``, ``<network_name>`` or ``default``.",
+          "examples": [
+            "bridge",
+            "host",
+            "none",
+            "container:<name|id>",
+            "default"
+          ],
+          "title": "Network Mode",
+          "type": "string"
+        },
+        "networks": {
+          "description": "List of networks the container will be connected to.",
+          "examples": [{ "name": "foo" }],
+          "items": {
+            "additionalProperties": true,
+            "properties": {
+              "aliases": {
+                "description": "Network aliases for the container on the given network.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "ipv4_address": {
+                "description": "IPv4 address for the container on the given network.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the network to connect to.",
+                "title": "Name",
+                "type": "string"
+              }
+            },
+            "required": ["name"],
+            "title": "Network",
+            "type": "object"
+          },
+          "title": "Networks",
+          "type": "array"
+        },
+        "networks_cli_compatible": {
+          "description": "Whether the networks option is handled in a way compatible with the Docker CLI.",
+          "title": "Networks CLI Compatible",
+          "type": "boolean"
+        },
+        "override_command": {
+          "description": "Whether or not to override the default command set by the container image.",
+          "title": "Override Command",
+          "type": "boolean"
+        },
+        "pid_mode": {
+          "description": "Set the PID mode for the container.",
+          "title": "PID Mode",
+          "type": "string"
+        },
+        "platform": {
+          "description": "Platform to build the image for, in the format ``os[/arch[/variant]]``.",
+          "examples": ["linux/amd64", "linux/arm64"],
+          "title": "Platform",
+          "type": "string"
+        },
+        "pre_build_image": {
+          "description": "Use a pre-built image instead of building one from a Dockerfile.",
+          "title": "Pre Build Image",
+          "type": "boolean"
+        },
+        "privileged": {
+          "description": "Give extended privileges to the container.",
+          "title": "Privileged",
+          "type": "boolean"
+        },
+        "published_ports": {
+          "description": "Publish a container's port, or range of ports, to the host. Format - \"ip:hostPort:containerPort\" | \"ip::containerPort\" | \"hostPort:containerPort\" | \"containerPort\".",
+          "examples": ["8080:80", "0.0.0.0:8053:53/udp"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Published Ports",
+          "type": "array"
+        },
+        "pull": {
+          "description": "Whether or not to pull the image.",
+          "title": "Pull",
+          "type": "boolean"
+        },
+        "purge_networks": {
+          "description": "Whether to purge the container from networks not listed in networks after creating or recreating it.",
+          "title": "Purge Networks",
+          "type": "boolean"
+        },
+        "registry": {
+          "additionalProperties": false,
+          "description": "Registry configuration.",
+          "properties": {
+            "credentials": {
+              "additionalProperties": false,
+              "description": "Credentials for the registry server.",
+              "properties": {
+                "email": {
+                  "description": "Email for the registry server.",
+                  "title": "Email",
+                  "type": "string"
+                },
+                "password": {
+                  "description": "Password for the registry server.",
+                  "title": "Password",
+                  "type": "string"
+                },
+                "user": {
+                  "description": "User for the registry server.",
+                  "title": "User",
+                  "type": "string"
+                },
+                "username": {
+                  "description": "Username for the registry server.",
+                  "title": "Username",
+                  "type": "string"
+                }
+              },
+              "required": ["username", "password"],
+              "title": "Credentials",
+              "type": "object"
+            },
+            "url": {
+              "description": "Registry server URL.",
+              "format": "uri",
+              "title": "Url",
+              "type": "string"
+            }
+          },
+          "title": "Registry",
+          "type": "object"
+        },
+        "restart_policy": {
+          "description": "Restart policy to follow when containers exit. Valid values are * no - Do not restart containers on exit * on-failure - Restart containers when they exit with a non-0 exit code, retrying indefinitely or until the optional restart_retries count is hit * always - Restart containers when they exit, regardless of status, retrying indefinitely * unless-stopped - Restart containers when they exit, regardless of status, retrying indefinitely, except when the container is put into a stopped state manually.",
+          "enum": ["no", "on-failure", "always", "unless-stopped"],
+          "title": "Restart Policy",
+          "type": "string"
+        },
+        "restart_retries": {
+          "description": "The number of times to retry restarting a container when the restart_policy is set to on-failure. This option is ignored when restart_policy is set to no or always.",
+          "minimum": 0,
+          "title": "Restart Retries",
+          "type": "integer"
+        },
+        "runtime": {
+          "description": "OCI runtime to use for the container.",
+          "title": "Runtime",
+          "type": "string"
+        },
+        "security_opts": {
+          "description": "Security Options.",
+          "examples": ["seccomp=unconfined", "label=disable"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Security Options",
+          "type": "array"
+        },
+        "shm_size": {
+          "description": "Size of /dev/shm for the container.",
+          "examples": ["64M"],
+          "title": "Shm Size",
+          "type": "string"
+        },
+        "stop_signal": {
+          "description": "Signal sent to the container when stopping it.",
+          "title": "Stop Signal",
+          "type": "string"
+        },
+        "sysctls": {
+          "additionalProperties": {
+            "type": ["string", "number"]
+          },
+          "description": "Dictionary of sysctl options to set in the container.",
+          "examples": [
+            { "net.core.somaxconn": 1024, "net.ipv4.tcp_syncookies": 0 }
+          ],
+          "title": "Sysctls",
+          "type": "object"
+        },
+        "tls_verify": {
+          "description": "Require HTTPS and verify certificates when contacting the Docker daemon. If explicitly set to true, then TLS verification will be used. If set to false, then TLS verification will not be used.",
+          "title": "TLS Verify",
+          "type": "boolean"
+        },
+        "tmpfs": {
+          "description": "Mount a tmpfs directory in the container.",
+          "examples": ["/tmp", "/run"],
+          "items": {
+            "type": "string"
+          },
+          "title": "tmpfs",
+          "type": "array"
+        },
+        "tty": {
+          "description": "Allocate a pseudo-TTY.",
+          "title": "TTY",
+          "type": "boolean"
+        },
+        "ulimits": {
+          "description": "Ulimit options.",
+          "examples": ["nofile:262144:262144"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Ulimits",
+          "type": "array"
+        },
+        "user": {
+          "description": "User to run the container as.",
+          "examples": ["root", "1000"],
+          "title": "User",
+          "type": "string"
+        },
+        "volumes": {
+          "description": "Create a bind mount. If you specify a volume ``/HOST-DIR:/CONTAINER-DIR``, Docker bind mounts ``/HOST-DIR`` on the host to ``/CONTAINER-DIR`` in the Docker container.",
+          "examples": ["/sys/fs/cgroup:/sys/fs/cgroup:ro"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Volumes",
+          "type": "array"
+        }
+      },
+      "required": ["name"],
+      "title": "MoleculePlatformModel",
+      "type": "object"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/ansible-community/molecule-plugins/main/src/molecule_plugins/docker/schema/driver.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "examples": ["molecule/*/molecule.yml"],
+  "properties": {
+    "driver": {
+      "$ref": "#/$defs/MoleculeDriverModel"
+    },
+    "platforms": {
+      "items": {
+        "$ref": "#/$defs/MoleculePlatformModel"
+      },
+      "title": "Platforms",
+      "type": "array"
+    }
+  },
+  "required": ["driver"],
+  "title": "Molecule Docker Driver Schema",
+  "type": "object"
+}

--- a/test/docker/conftest.py
+++ b/test/docker/conftest.py
@@ -6,6 +6,6 @@ import pytest
 
 
 @pytest.fixture()
-def DRIVER():
+def driver_name():
     """Return name of the driver to be tested."""
     return "docker"

--- a/test/docker/test_driver.py
+++ b/test/docker/test_driver.py
@@ -1,8 +1,122 @@
 """Unit tests."""
 
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError, validate
+
 from molecule import api
 
 
-def test_docker_driver_is_detected(DRIVER):
+def test_docker_driver_is_detected(driver_name: str):
     """Asserts that molecule recognizes the driver."""
-    assert DRIVER in [str(d) for d in api.drivers()]
+    assert driver_name in [str(d) for d in api.drivers()]
+
+
+def test_docker_driver_provides_schema(driver_name: str):
+    """Asserts that the docker driver provides a JSON schema file."""
+    driver = api.drivers()[driver_name]
+    schema_file = driver.schema_file()
+
+    assert schema_file is not None
+    assert Path(schema_file).is_file()
+    assert schema_file.endswith(driver_name + "/schema/driver.json")
+
+
+def test_docker_driver_schema_is_valid(driver_name: str):
+    """Asserts that the docker driver schema is a valid JSON Schema."""
+    schema_file = api.drivers()[driver_name].schema_file()
+    schema = json.loads(Path(schema_file).read_text())
+    Draft202012Validator.check_schema(schema)
+
+
+@pytest.mark.parametrize(
+    ("config", "valid"),
+    [
+        # Minimal valid configuration
+        (
+            {
+                "driver": {"name": "docker"},
+                "platforms": [{"name": "instance", "image": "image:tag"}],
+            },
+            True,
+        ),
+        # Comprehensive configuration exercising all documented options
+        (
+            {
+                "driver": {"name": "docker"},
+                "platforms": [
+                    {
+                        "name": "instance",
+                        "hostname": "instance",
+                        "image": "image:tag",
+                        "dockerfile": "Dockerfile.j2",
+                        "pull": True,
+                        "pre_build_image": False,
+                        "registry": {
+                            "url": "registry.example.com",
+                            "credentials": {"username": "u", "password": "p"},
+                        },
+                        "override_command": True,
+                        "command": "sleep infinity",
+                        "tty": True,
+                        "pid_mode": "host",
+                        "privileged": True,
+                        "security_opts": ["seccomp=unconfined"],
+                        "cgroupns_mode": "host",
+                        "shm_size": "64M",
+                        "devices": ["/dev/fuse:/dev/fuse:rwm"],
+                        "volumes": ["/sys/fs/cgroup:/sys/fs/cgroup:ro"],
+                        "keep_volumes": True,
+                        "tmpfs": ["/tmp", "/run"],
+                        "capabilities": ["SYS_ADMIN"],
+                        "sysctls": {"net.core.somaxconn": 1024},
+                        "exposed_ports": ["53/udp"],
+                        "published_ports": ["0.0.0.0:8053:53/udp"],
+                        "ulimits": ["nofile:262144:262144"],
+                        "dns_servers": ["8.8.8.8"],
+                        "etc_hosts": {"host1.example.com": "10.3.1.5"},
+                        "docker_networks": [{"name": "foo"}],
+                        "networks": [{"name": "foo"}],
+                        "network_mode": "host",
+                        "purge_networks": True,
+                        "docker_host": "tcp://localhost:12376",
+                        "cacert_path": "/foo/bar/ca.pem",
+                        "cert_path": "/foo/bar/cert.pem",
+                        "key_path": "/foo/bar/key.pem",
+                        "tls_verify": True,
+                        "env": {"FOO": "bar"},
+                        "restart_policy": "unless-stopped",
+                        "restart_retries": 1,
+                        "buildargs": {"http_proxy": "http://proxy:8080/"},
+                        "cache_from": ["registry.example.com/example:main"],
+                        "user": "root",
+                        "memory": "512m",
+                        "platform": "linux/amd64",
+                    }
+                ],
+            },
+            True,
+        ),
+        # Podman-only options must be rejected
+        (
+            {
+                "driver": {"name": "docker"},
+                "platforms": [
+                    {"name": "instance", "image": "image:tag", "systemd": "true"}
+                ],
+            },
+            False,
+        ),
+    ],
+)
+def test_docker_driver_schema_validation(config, valid):
+    """Asserts that the docker driver schema accepts/rejects configs correctly."""
+    schema_file = api.drivers()["docker"].schema_file()
+    schema = json.loads(Path(schema_file).read_text())
+    if valid:
+        validate(instance=config, schema=schema)
+    else:
+        with pytest.raises(ValidationError):
+            validate(instance=config, schema=schema)

--- a/test/docker/test_func.py
+++ b/test/docker/test_func.py
@@ -45,7 +45,9 @@ def format_result(result: subprocess.CompletedProcess):
     not is_docker_available(),
     reason="Docker not available or daemon not reachable",
 )
-def test_command_init_and_test_scenario(tmp_path: pathlib.Path, DRIVER: str) -> None:
+def test_command_init_and_test_scenario(
+    tmp_path: pathlib.Path, driver_name: str
+) -> None:
     """Verify that init scenario works."""
     shutil.rmtree(tmp_path, ignore_errors=True)
     tmp_path.mkdir(exist_ok=True)
@@ -62,7 +64,7 @@ def test_command_init_and_test_scenario(tmp_path: pathlib.Path, DRIVER: str) -> 
         ]
         result = get_app(tmp_path).run_command(cmd)
         assert result.returncode == 0
-        set_driver_in_scenario_molecule_yml(str(scenario_directory), DRIVER)
+        set_driver_in_scenario_molecule_yml(str(scenario_directory), driver_name)
 
         assert scenario_directory.exists()
 


### PR DESCRIPTION
Currently, when running molecule with the docker driver, we get the following message:

```
WARNING  Driver docker does not provide a schema.
```

So, let's add a schema 🎉 