### PR TITLE
feat(containers): Add driver schema

### DIFF
--- a/src/molecule_plugins/containers/driver.py
+++ b/src/molecule_plugins/containers/driver.py
@@ -1,8 +1,11 @@
 """Containers Driver Module."""
 
+from __future__ import annotations
+
 import inspect
 import os
 import shutil
+from pathlib import Path
 
 from molecule import logger
 
@@ -51,3 +54,18 @@ class Container(DriverBackend):
             "community.docker": "3.10.2",  # keep in sync with src/molecule_plugins/docker/driver.py and requirements.yml
             "containers.podman": "1.8.1",
         }
+
+    def schema_file(self) -> str | None:
+        """Return the path to the driver's JSON schema file.
+
+        ``self._path`` points at the backend driver (docker or podman) so that
+        molecule can find the embedded playbooks. The schema, however, is
+        specific to the agnostic *containers* driver, so resolve it relative to
+        this module instead of the backend.
+        """
+        p = Path(
+            os.path.dirname(inspect.getfile(self.__class__)), "schema", "driver.json"
+        )
+        if p.is_file():
+            return str(p)
+        return None

--- a/src/molecule_plugins/containers/schema/driver.json
+++ b/src/molecule_plugins/containers/schema/driver.json
@@ -1,0 +1,271 @@
+{
+  "$defs": {
+    "MoleculeDriverModel": {
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "enum": ["containers"],
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": ["name"],
+      "title": "MoleculeDriverModel",
+      "type": "object"
+    },
+    "MoleculePlatformModel": {
+      "additionalProperties": false,
+      "properties": {
+        "buildargs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arguments that control image build.",
+          "examples": [{ "http_proxy": "http://proxy.example.com:8080/" }],
+          "title": "Build Arguments",
+          "type": "object"
+        },
+        "capabilities": {
+          "description": "List of capabilities to add to the container.",
+          "examples": ["SYS_ADMIN", "NET_ADMIN"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Capabilities",
+          "type": "array"
+        },
+        "cert_path": {
+          "description": "Path to a TLS certificate file. With the docker backend it authenticates with the Docker daemon; with the podman backend it provides certificates (*.crt, *.cert, *.key) to connect to the registry.",
+          "title": "Cert Path",
+          "type": "string"
+        },
+        "command": {
+          "description": "Override command of container.",
+          "examples": ["/sbin/init", "sleep infinity"],
+          "title": "Command",
+          "type": "string"
+        },
+        "devices": {
+          "description": "List of device mappings to add a host device to the container. The format is <device-on-host>[:<device-on-container>][:<permissions>].",
+          "examples": ["/dev/fuse:/dev/fuse:rwm"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Devices",
+          "type": "array"
+        },
+        "dns_servers": {
+          "description": "List of DNS servers for the container to use.",
+          "examples": ["8.8.8.8", "1.1.1.1"],
+          "items": {
+            "type": "string"
+          },
+          "title": "DNS Servers",
+          "type": "array"
+        },
+        "dockerfile": {
+          "description": "Path to a Dockerfile.j2 file used to build the image.",
+          "title": "Dockerfile",
+          "type": "string"
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Set environment variables. This option allows you to specify arbitrary environment variables that are available for the process that will be launched inside of the container.",
+          "examples": [{ "BAZ": "qux", "FOO": "bar" }],
+          "title": "Environment",
+          "type": "object"
+        },
+        "etc_hosts": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Dict of host-to-IP mappings, where each host name is a key in the dictionary. Each host name will be added to the container's ``/etc/hosts`` file.",
+          "examples": [{ "host1.example.com": "10.3.1.5" }],
+          "title": "etc hosts",
+          "type": "object"
+        },
+        "exposed_ports": {
+          "description": "List of ports to expose on the container.",
+          "examples": ["53/udp", "53/tcp"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Exposed Ports",
+          "type": "array"
+        },
+        "groups": {
+          "description": "List of inventory groups to add the instance to.",
+          "examples": ["webserver", "db"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Groups",
+          "type": "array"
+        },
+        "hostname": {
+          "description": "Container host name. Sets the container host name that is available inside the container.",
+          "title": "Hostname",
+          "type": "string"
+        },
+        "image": {
+          "description": "Repository path (or image name) and tag used to create the container. If an image is not found, the image will be pulled from the registry. If no tag is included, latest will be used.",
+          "title": "Image",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the container",
+          "title": "Name",
+          "type": "string"
+        },
+        "override_command": {
+          "description": "Whether or not to override the default command set by the container image.",
+          "title": "Override Command",
+          "type": "boolean"
+        },
+        "pid_mode": {
+          "description": "Set the PID mode for the container.",
+          "title": "PID Mode",
+          "type": "string"
+        },
+        "pre_build_image": {
+          "description": "Use a pre-built image instead of building one from a Dockerfile.",
+          "title": "Pre Build Image",
+          "type": "boolean"
+        },
+        "privileged": {
+          "description": "Give extended privileges to the container.",
+          "title": "Privileged",
+          "type": "boolean"
+        },
+        "published_ports": {
+          "description": "Publish a container's port, or range of ports, to the host. Format - \"ip:hostPort:containerPort\" | \"ip::containerPort\" | \"hostPort:containerPort\" | \"containerPort\".",
+          "examples": ["8080:80", "0.0.0.0:8053:53/udp"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Published Ports",
+          "type": "array"
+        },
+        "pull": {
+          "description": "Whether or not to pull the image.",
+          "title": "Pull",
+          "type": "boolean"
+        },
+        "registry": {
+          "additionalProperties": false,
+          "description": "Registry configuration.",
+          "properties": {
+            "credentials": {
+              "additionalProperties": false,
+              "description": "Credentials for the registry server.",
+              "properties": {
+                "password": {
+                  "description": "Password for the registry server.",
+                  "title": "Password",
+                  "type": "string"
+                },
+                "username": {
+                  "description": "Username for the registry server.",
+                  "title": "Username",
+                  "type": "string"
+                }
+              },
+              "required": ["username", "password"],
+              "title": "Credentials",
+              "type": "object"
+            },
+            "url": {
+              "description": "Registry server URL.",
+              "format": "uri",
+              "title": "Url",
+              "type": "string"
+            }
+          },
+          "title": "Registry",
+          "type": "object"
+        },
+        "restart_policy": {
+          "description": "Restart policy to follow when containers exit. Valid values are * no - Do not restart containers on exit. (This needs to be quoted, otherwise it will parse to false) * on-failure - Restart containers when they exit with a non-0 exit code, retrying indefinitely or until the optional restart_retries count is hit * always - Restart containers when they exit, regardless of status, retrying indefinitely",
+          "enum": ["no", "on-failure", "always"],
+          "title": "Restart Policy",
+          "type": "string"
+        },
+        "restart_retries": {
+          "description": "The number of times to retry restarting a container when the restart_policy is set to on-failure. This option is ignored when restart_policy is set to no or always.",
+          "minimum": 0,
+          "title": "Restart Retries",
+          "type": "integer"
+        },
+        "security_opts": {
+          "description": "Security Options.",
+          "examples": ["seccomp=unconfined"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Security Options",
+          "type": "array"
+        },
+        "tls_verify": {
+          "description": "Require HTTPS and verify certificates when contacting the daemon or registry. If explicitly set to true, then TLS verification will be used. If set to false, then TLS verification will not be used.",
+          "title": "TLS Verify",
+          "type": "boolean"
+        },
+        "tmpfs": {
+          "description": "Mount a tmpfs directory in the container.",
+          "examples": ["/tmp", "/run"],
+          "items": {
+            "type": "string"
+          },
+          "title": "tmpfs",
+          "type": "array"
+        },
+        "tty": {
+          "description": "Allocate a pseudo-TTY.",
+          "title": "TTY",
+          "type": "boolean"
+        },
+        "ulimits": {
+          "description": "Ulimit options.",
+          "examples": ["nofile:262144:262144"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Ulimits",
+          "type": "array"
+        },
+        "volumes": {
+          "description": "Create a bind mount. If you specify a volume ``/HOST-DIR:/CONTAINER-DIR``, the host directory is bind-mounted into the container.",
+          "examples": ["/sys/fs/cgroup:/sys/fs/cgroup:ro"],
+          "items": {
+            "type": "string"
+          },
+          "title": "Volumes",
+          "type": "array"
+        }
+      },
+      "required": ["name"],
+      "title": "MoleculePlatformModel",
+      "type": "object"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/ansible-community/molecule-plugins/main/src/molecule_plugins/containers/schema/driver.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "examples": ["molecule/*/molecule.yml"],
+  "properties": {
+    "driver": {
+      "$ref": "#/$defs/MoleculeDriverModel"
+    },
+    "platforms": {
+      "items": {
+        "$ref": "#/$defs/MoleculePlatformModel"
+      },
+      "title": "Platforms",
+      "type": "array"
+    }
+  },
+  "required": ["driver"],
+  "title": "Molecule Containers Driver Schema",
+  "type": "object"
+}

--- a/test/containers/conftest.py
+++ b/test/containers/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest Fixtures."""
+
+from conftest import random_string, temp_dir  # noqa
+
+import pytest
+
+
+@pytest.fixture()
+def driver_name():
+    """Return name of the driver to be tested."""
+    return "containers"

--- a/test/containers/test_driver.py
+++ b/test/containers/test_driver.py
@@ -1,8 +1,173 @@
-"""Unit Tests."""
+"""Unit tests."""
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError, validate
 
 from molecule import api
 
 
-def test_container_driver_is_detected():
-    """Check that driver is recognized."""
-    assert "containers" in [str(d) for d in api.drivers()]
+def test_container_driver_is_detected(driver_name: str):
+    """Asserts that molecule recognizes the driver."""
+    assert driver_name in [str(d) for d in api.drivers()]
+
+
+def test_container_driver_provides_schema(driver_name: str):
+    """Asserts that the containers driver provides a JSON schema file."""
+    driver = api.drivers()[driver_name]
+    schema_file = driver.schema_file()
+
+    assert schema_file is not None
+    assert Path(schema_file).is_file()
+    assert schema_file.endswith(driver_name + "/schema/driver.json")
+
+
+def test_container_driver_schema_is_valid(driver_name: str):
+    """Asserts that the containers driver schema is a valid JSON Schema."""
+    schema_file = api.drivers()[driver_name].schema_file()
+    schema = json.loads(Path(schema_file).read_text())
+    Draft202012Validator.check_schema(schema)
+
+
+@pytest.mark.parametrize(
+    ("config", "valid"),
+    [
+        # Minimal valid configuration
+        (
+            {
+                "driver": {"name": "containers"},
+                "platforms": [{"name": "instance", "image": "image:tag"}],
+            },
+            True,
+        ),
+        # Comprehensive configuration exercising all documented options. Only
+        # options that are portable across both the docker and podman backends
+        # are accepted by the agnostic containers driver schema.
+        (
+            {
+                "driver": {"name": "containers"},
+                "platforms": [
+                    {
+                        "name": "instance",
+                        "hostname": "instance",
+                        "image": "image:tag",
+                        "dockerfile": "Dockerfile.j2",
+                        "pull": True,
+                        "pre_build_image": False,
+                        "registry": {
+                            "url": "registry.example.com",
+                            "credentials": {"username": "u", "password": "p"},
+                        },
+                        "override_command": True,
+                        "command": "sleep infinity",
+                        "tty": True,
+                        "pid_mode": "host",
+                        "privileged": True,
+                        "security_opts": ["seccomp=unconfined"],
+                        "devices": ["/dev/fuse:/dev/fuse:rwm"],
+                        "volumes": ["/sys/fs/cgroup:/sys/fs/cgroup:ro"],
+                        "tmpfs": ["/tmp", "/run"],
+                        "capabilities": ["SYS_ADMIN"],
+                        "exposed_ports": ["53/udp"],
+                        "published_ports": ["0.0.0.0:8053:53/udp"],
+                        "ulimits": ["nofile:262144:262144"],
+                        "dns_servers": ["8.8.8.8"],
+                        "etc_hosts": {"host1.example.com": "10.3.1.5"},
+                        "env": {"FOO": "bar"},
+                        "groups": ["webserver", "db"],
+                        "cert_path": "/foo/bar/cert.pem",
+                        "tls_verify": True,
+                        "restart_policy": "on-failure",
+                        "restart_retries": 1,
+                        "buildargs": {"http_proxy": "http://proxy:8080/"},
+                    }
+                ],
+            },
+            True,
+        ),
+        # Docker-only option must be rejected
+        (
+            {
+                "driver": {"name": "containers"},
+                "platforms": [
+                    {
+                        "name": "instance",
+                        "image": "image:tag",
+                        "docker_networks": [{"name": "foo"}],
+                    }
+                ],
+            },
+            False,
+        ),
+        # Podman-only option must be rejected
+        (
+            {
+                "driver": {"name": "containers"},
+                "platforms": [
+                    {"name": "instance", "image": "image:tag", "systemd": "true"}
+                ],
+            },
+            False,
+        ),
+        # "unless-stopped" is docker-only and not portable across backends
+        (
+            {
+                "driver": {"name": "containers"},
+                "platforms": [
+                    {
+                        "name": "instance",
+                        "image": "image:tag",
+                        "restart_policy": "unless-stopped",
+                    }
+                ],
+            },
+            False,
+        ),
+        # A list of commands is podman-only; the portable form is a string
+        (
+            {
+                "driver": {"name": "containers"},
+                "platforms": [
+                    {
+                        "name": "instance",
+                        "image": "image:tag",
+                        "command": ["sleep", "infinity"],
+                    }
+                ],
+            },
+            False,
+        ),
+        # registry.credentials.email is docker-only and not portable
+        (
+            {
+                "driver": {"name": "containers"},
+                "platforms": [
+                    {
+                        "name": "instance",
+                        "image": "image:tag",
+                        "registry": {
+                            "url": "registry.example.com",
+                            "credentials": {
+                                "username": "u",
+                                "password": "p",
+                                "email": "u@example.com",
+                            },
+                        },
+                    }
+                ],
+            },
+            False,
+        ),
+    ],
+)
+def test_container_driver_schema_validation(config, valid):
+    """Asserts that the containers driver schema accepts/rejects configs correctly."""
+    schema_file = api.drivers()["containers"].schema_file()
+    schema = json.loads(Path(schema_file).read_text())
+    if valid:
+        validate(instance=config, schema=schema)
+    else:
+        with pytest.raises(ValidationError):
+            validate(instance=config, schema=schema)


### PR DESCRIPTION
Currently, when running molecule with the containers driver, we get the following message:

```
WARNING  Driver container does not provide a schema.
```

So, let's add a schema 🎉