### PR TITLE
Fix: openstack driver instances retrieval in Ansible 2.19

### DIFF
--- a/src/molecule_plugins/openstack/playbooks/prepare.yml
+++ b/src/molecule_plugins/openstack/playbooks/prepare.yml
@@ -27,7 +27,7 @@
 
     - name: Set molecule instances
       ansible.builtin.set_fact:
-        instances: "{{ lookup('file', molecule_instance_config) }}"
+        instances: "{{ lookup('file', molecule_instance_config) | from_yaml }}"
       when: raw_uname.rc == 0 and raw_uname.stdout | trim == "Linux"
 
     - name: Save molecule instances


### PR DESCRIPTION
Fix error `object of type 'str' has no attribute 'instance'` with Ansible 2.19