### PR TITLE
feat: Use docker connection variables specified in 'platforms'

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -37,6 +37,9 @@ sameas
 slirp
 tcp_syncookies
 testinfra
+tlscacert
+tlscert
+tlskey
 tlsverify
 tmpfs
 vagrantdir

--- a/src/molecule_plugins/docker/playbooks/create.yml
+++ b/src/molecule_plugins/docker/playbooks/create.yml
@@ -92,6 +92,8 @@
       loop_control:
         label: "{{ item.name }}"
       no_log: false
+      vars:
+        ctx: "{{ molecule_yml.platforms | selectattr('name', 'equalto', item.platform) | first }}"
 
     - name: Build an Ansible compatible image (new) # noqa: no-handler
       when:

--- a/src/molecule_plugins/docker/playbooks/destroy.yml
+++ b/src/molecule_plugins/docker/playbooks/destroy.yml
@@ -50,3 +50,5 @@
       loop_control:
         label: "{{ item.name }}"
       no_log: false
+      vars:
+        ctx: "{{ molecule_yml.platforms | selectattr('name', 'equalto', item.platform) | first }}"

--- a/src/molecule_plugins/docker/playbooks/filter_plugins/get_docker_networks.py
+++ b/src/molecule_plugins/docker/playbooks/filter_plugins/get_docker_networks.py
@@ -8,6 +8,8 @@ def get_docker_networks(data, labels={}):
     for platform in data:
         if "docker_networks" in platform:
             for docker_network in platform["docker_networks"]:
+                docker_network["platform"] = platform["name"]
+
                 if "labels" not in docker_network:
                     docker_network["labels"] = {}
                 for key in labels:
@@ -24,7 +26,13 @@ def get_docker_networks(data, labels={}):
                 if "name" in network:
                     name = network["name"]
                     if name not in network_names:
-                        network_list.append({"name": name, "labels": labels})
+                        network_list.append(
+                            {
+                                "platform": platform["name"],
+                                "name": name,
+                                "labels": labels,
+                            }
+                        )
     return network_list
 
 

--- a/src/molecule_plugins/docker/playbooks/tasks/create_network.yml
+++ b/src/molecule_plugins/docker/playbooks/tasks/create_network.yml
@@ -1,20 +1,30 @@
 ---
 - name: Check if network exist
   community.docker.docker_network_info:
+    api_version: "{{ ctx.api_version | default(omit) }}"
+    ca_cert: "{{ ctx.ca_cert | default(omit) }}"
+    client_cert: "{{ ctx.client_cert | default(omit) }}"
+    client_key: "{{ ctx.client_key | default(omit) }}"
+    docker_host: "{{ ctx.docker_host | default(omit) }}"
     name: "{{ item.name }}"
+    ssl_version: "{{ ctx.ssl_version | default(omit) }}"
+    timeout: "{{ ctx.timeout | default(omit) }}"
+    tls: "{{ ctx.tls | default(omit) }}"
+    tls_hostname: "{{ ctx.tls_hostname | default(omit) }}"
+    validate_certs: "{{ ctx.validate_certs | default(omit) }}"
   register: docker_netname
 
 - name: Create docker network(s)
   community.docker.docker_network:
-    api_version: "{{ item.api_version | default(omit) }}"
+    api_version: "{{ ctx.api_version | default(omit) }}"
     appends: "{{ item.appends | default(omit) }}"
     attachable: "{{ item.attachable | default(omit) }}"
-    ca_cert: "{{ item.ca_cert | default(omit) }}"
-    client_cert: "{{ item.client_cert | default(omit) }}"
-    client_key: "{{ item.client_key | default(omit) }}"
+    ca_cert: "{{ ctx.ca_cert | default(omit) }}"
+    client_cert: "{{ ctx.client_cert | default(omit) }}"
+    client_key: "{{ ctx.client_key | default(omit) }}"
     connected: "{{ item.connected | default(omit) }}"
     debug: "{{ item.debug | default(omit) }}"
-    docker_host: "{{ item.docker_host | default(omit) }}"
+    docker_host: "{{ ctx.docker_host | default(omit) }}"
     driver: "{{ item.driver | default(omit) }}"
     driver_options: "{{ item.driver_options | default(omit) }}"
     enable_ipv6: "{{ item.enable_ipv6 | default(omit) }}"
@@ -27,10 +37,10 @@
     labels: "{{ item.labels }}"
     name: "{{ item.name }}"
     scope: "{{ item.scope | default(omit) }}"
-    ssl_version: "{{ item.ssl_version | default(omit) }}"
+    ssl_version: "{{ ctx.ssl_version | default(omit) }}"
     state: "present"
-    timeout: "{{ item.timeout | default(omit) }}"
-    tls: "{{ item.tls | default(omit) }}"
-    tls_hostname: "{{ item.tls_hostname | default(omit) }}"
-    validate_certs: "{{ item.validate_certs | default(omit) }}"
+    timeout: "{{ ctx.timeout | default(omit) }}"
+    tls: "{{ ctx.tls | default(omit) }}"
+    tls_hostname: "{{ ctx.tls_hostname | default(omit) }}"
+    validate_certs: "{{ ctx.validate_certs | default(omit) }}"
   when: not docker_netname.exists

--- a/src/molecule_plugins/docker/playbooks/tasks/delete_network.yml
+++ b/src/molecule_plugins/docker/playbooks/tasks/delete_network.yml
@@ -1,13 +1,33 @@
 ---
 - name: Retrieve network info
   community.docker.docker_network_info:
+    api_version: "{{ ctx.api_version | default(omit) }}"
+    ca_cert: "{{ ctx.ca_cert | default(omit) }}"
+    client_cert: "{{ ctx.client_cert | default(omit) }}"
+    client_key: "{{ ctx.client_key | default(omit) }}"
+    docker_host: "{{ ctx.docker_host | default(omit) }}"
     name: "{{ item.name }}"
+    ssl_version: "{{ ctx.ssl_version | default(omit) }}"
+    timeout: "{{ ctx.timeout | default(omit) }}"
+    tls: "{{ ctx.tls | default(omit) }}"
+    tls_hostname: "{{ ctx.tls_hostname | default(omit) }}"
+    validate_certs: "{{ ctx.validate_certs | default(omit) }}"
   register: docker_netname
 
 - name: Delete docker network(s)
   community.docker.docker_network:
+    api_version: "{{ ctx.api_version | default(omit) }}"
+    ca_cert: "{{ ctx.ca_cert | default(omit) }}"
+    client_cert: "{{ ctx.client_cert | default(omit) }}"
+    client_key: "{{ ctx.client_key | default(omit) }}"
+    docker_host: "{{ ctx.docker_host | default(omit) }}"
     name: "{{ item.name }}"
     state: "absent"
+    ssl_version: "{{ ctx.ssl_version | default(omit) }}"
+    timeout: "{{ ctx.timeout | default(omit) }}"
+    tls: "{{ ctx.tls | default(omit) }}"
+    tls_hostname: "{{ ctx.tls_hostname | default(omit) }}"
+    validate_certs: "{{ ctx.validate_certs | default(omit) }}"
   when:
     - docker_netname.exists
     - docker_netname.network.Labels.owner is defined


### PR DESCRIPTION
Currently, the connection attributes specified in _platforms_ are ignored, despite being in the schema. They're wired up but the 'sanity' check assumes that any config for connecting to dockerd comes from environment variables so unless you're using dockerd locally or executing molecule on a container host directly, the check will fail. It also assumes that one would only ever want to connect to a single dockerd.

This causes some weird behaviour - because the variables are wired up in the playbooks, molecule will run the sanity checks against your local dockerd, and then run the tests against the configured one - meaning your tests will randomly fail depending on whether you've got dockerd running locally, even though it's not used.

This change preserves the existing behaviour as far as possible as it still looks at the environment first and attempts to connect with defaults. If that fails, it then looks for connection details specified as attributes in each platform entry. It should also be possible to run tests on different dockerd instances (e.g. to target aarch64 and x86_64).

Some changes were needed to create/destroy.yml, as the connection variables weren't used for the network create/update operations.

Error handling is improved a little, as it wasn't obvious why the 'sanity' checks were failing.

There are some CI failures, but I believe they're unrelated.

With two platforms defined - one pointing to `unix:///Users/adamb/.rd/docker.sock` and the other to `unix:///Users/adamb/.rd/docker2.sock`
```
...
INFO     Sanity checks: 'docker'
INFO     Successfully connected using settings defined in fedora
INFO     Successfully connected using settings defined in bedora
...
TASK [Check presence of custom Dockerfiles] ************************************
ok: [localhost] => (item=fedora) => {"ansible_loop_var": "item", "changed": false, "item": {"docker_host": "unix:///Users/adamb/.rd/docker.sock", "docker_networks": [{"ipam_config": [{"gateway": "10.3.1.254", "subnet": "10.3.1.0/24"}], "name": "foo"}], "image": "fedora:latest", "name": "fedora", "networks": [{"name": "foo"}, {"name": "bar"}]}, "stat": {"exists": false}}
ok: [localhost] => (item=bedora) => {"ansible_loop_var": "item", "changed": false, "item": {"docker_host": "unix:///Users/adamb/.rd/docker2.sock", "docker_networks": [{"ipam_config": [{"gateway": "10.3.1.254", "subnet": "10.3.1.0/24"}], "name": "foo"}], "image": "fedora:latest", "name": "bedora", "networks": [{"name": "foo"}, {"name": "bar"}]}, "stat": {"exists": false}}
```