### PR TITLE
Replace connection variable with ansible_connection

### DIFF
--- a/src/molecule_plugins/azure/driver.py
+++ b/src/molecule_plugins/azure/driver.py
@@ -119,7 +119,7 @@ class Azure(Driver):
                 "ansible_host": d["address"],
                 "ansible_port": d["port"],
                 "ansible_private_key_file": d["identity_file"],
-                "connection": "ssh",
+                "ansible_connection": "ssh",
                 "ansible_ssh_common_args": " ".join(self.ssh_connection_options),
             }
         except StopIteration:

--- a/src/molecule_plugins/ec2/driver.py
+++ b/src/molecule_plugins/ec2/driver.py
@@ -232,7 +232,7 @@ class EC2(Driver):
                     "ansible_host": d["address"],
                     "ansible_port": d["port"],
                     "ansible_private_key_file": d["identity_file"],
-                    "connection": "ssh",
+                    "ansible_connection": "ssh",
                     "ansible_ssh_common_args": " ".join(self.ssh_connection_options),
                 },
                 plat_conn_opts,

--- a/src/molecule_plugins/openstack/driver.py
+++ b/src/molecule_plugins/openstack/driver.py
@@ -151,7 +151,7 @@ class Openstack(Driver):
                 "ansible_host": d["address"],
                 "ansible_port": d["port"],
                 "ansible_private_key_file": d["identity_file"],
-                "connection": "ssh",
+                "ansible_connection": "ssh",
                 "ansible_ssh_common_args": " ".join(self.ssh_connection_options),
             }
         except StopIteration:

--- a/src/molecule_plugins/vagrant/driver.py
+++ b/src/molecule_plugins/vagrant/driver.py
@@ -185,7 +185,7 @@ class Vagrant(Driver):
                 "ansible_host": d["address"],
                 "ansible_port": d["port"],
                 "ansible_private_key_file": d["identity_file"],
-                "connection": "ssh",
+                "ansible_connection": "ssh",
                 "ansible_ssh_common_args": " ".join(self.ssh_connection_options),
             }
         except StopIteration:


### PR DESCRIPTION
The connection variable is deprecated, instead `ansible_connection` should be used.

see: [intro_inventory](https://docs.ansible.com/ansible/latest/inventory_guide/intro_inventory.html#connecting-to-hosts-behavioral-inventory-parameters)

There's usually a warning about it:

```
[WARNING]: Found variable using reserved name 'connection'.
Origin: /root/.cache/molecule/test.libvirt/default/inventory/ansible_inventory.yml:23:7
21         -o StrictHostKeyChecking=no
22       ansible_user: vagrant
23       connection: ssh
```