### PR TITLE
Fix: Ensure correct Vagrantfile rendering with multiple interfaces

### DIFF
--- a/src/molecule_plugins/vagrant/modules/vagrant.py
+++ b/src/molecule_plugins/vagrant/modules/vagrant.py
@@ -251,7 +251,7 @@ Vagrant.configure('2') do |config|
 
     # Network
     {% for n in instance.networks %}
-    c.vm.network "{{ n.name }}"{% if 'options' in n %}, {{ dict2args(n.options) | trim }}{% endif %}
+    c.vm.network "{{ n.name }}"{% if 'options' in n %}, {{ dict2args(n.options) | trim }}{% endif +%}
     {% endfor %}
     {% endif %}
     {% if instance.instance_raw_config_args is not none %}


### PR DESCRIPTION
Regression from #102: {% endif %} at end of c.vm.network line swallows
  trailing newline due to trim_blocks=True, merging consecutive network lines into invalid Ruby. Fix: use {% endif +%} to preserve the newline.

This fixes https://github.com/ansible-community/molecule-plugins/issues/373
