### PR TITLE
fix: enhancement: Including files in source distributions with MANIFEST.in (#156)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include LICENSE
+include README.md
+
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]
+
+recursive-include src/molecule_plugins/*/cookiecutter **/*
+recursive-include src/molecule_plugins/*/modules **/*
+recursive-include src/molecule_plugins/*/playbooks **/*


### PR DESCRIPTION
https://github.com/ansible-community/molecule-plugins/commit/6aae554da10a04fa2fbd417bb3c70b36fd9fbdb1 carelessly remove the MANIFEST.in, so now vagrant plugin missing create.yml

After cherry-pick original commit, following files come back:
```
debian/tmp/usr/lib/python3.14/dist-packages/molecule_plugins/vagrant/cookiecutter/cookiecutter.json
debian/tmp/usr/lib/python3.14/dist-packages/molecule_plugins/vagrant/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/converge.yml
debian/tmp/usr/lib/python3.14/dist-packages/molecule_plugins/vagrant/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/INSTALL.rst
debian/tmp/usr/lib/python3.14/dist-packages/molecule_plugins/vagrant/driver.py
debian/tmp/usr/lib/python3.14/dist-packages/molecule_plugins/vagrant/__init__.py
debian/tmp/usr/lib/python3.14/dist-packages/molecule_plugins/vagrant/modules/__init__.py
debian/tmp/usr/lib/python3.14/dist-packages/molecule_plugins/vagrant/modules/vagrant.py
debian/tmp/usr/lib/python3.14/dist-packages/molecule_plugins/vagrant/playbooks/create.yml
debian/tmp/usr/lib/python3.14/dist-packages/molecule_plugins/vagrant/playbooks/destroy.yml
debian/tmp/usr/lib/python3.14/dist-packages/molecule_plugins/vagrant/playbooks/prepare.yml
```

See https://github.com/ansible-community/molecule-plugins/pull/156


[PATCH] Including files in source distributions with MANIFEST.in

When packaging as .deb/.rpm with setuptools (sometime without setuptools_scm), some required template files are excluded from the final packaging result, unless specify them within `MANIFEST.in`.

See https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html See https://packaging.python.org/en/latest/guides/using-manifest-in