### PR TITLE
fix(ec2): support Molecule config_data

### DIFF
--- a/src/molecule_plugins/ec2/driver.py
+++ b/src/molecule_plugins/ec2/driver.py
@@ -215,15 +215,18 @@ class EC2(Driver):
 
         return util.merge_dicts(d, self._get_instance_config(instance_name))
 
+    @property
+    def platforms(self):
+        config_data = getattr(self._config, "config_data", None)
+        if config_data is None:
+            config_data = self._config.config
+        return config_data.get("platforms", [])
+
     def ansible_connection_options(self, instance_name):
         try:
             d = self._get_instance_config(instance_name)
             plat_conn_opts = next(
-                (
-                    item
-                    for item in self._config.config.get("platforms", [])
-                    if item["name"] == instance_name
-                ),
+                (item for item in self.platforms if item["name"] == instance_name),
                 {},
             ).get("connection_options", {})
             conn_opts = util.merge_dicts(

--- a/test/ec2/test_driver.py
+++ b/test/ec2/test_driver.py
@@ -1,5 +1,18 @@
+from types import SimpleNamespace
+
+import pytest
+
 from molecule import api
+from molecule_plugins.ec2.driver import EC2
 
 
 def test_ec2_driver_is_detected():
     assert "ec2" in [str(d) for d in api.drivers()]
+
+
+@pytest.mark.parametrize("config_attribute", ["config", "config_data"])
+def test_ec2_driver_supports_molecule_config_attributes(config_attribute):
+    platforms = [{"name": "instance"}]
+    driver = EC2(SimpleNamespace(**{config_attribute: {"platforms": platforms}}))
+
+    assert driver.platforms == platforms


### PR DESCRIPTION
## Summary
- Support Molecule 26.8.0+ by reading platform settings from `Config.config_data`.
- Keep the `Config.config` fallback for earlier Molecule releases.
- Add a regression test for both attribute names.

## Issue
Fixes #379.

Molecule 26.8.0 renamed `Config.config` to `Config.config_data` in [ansible/molecule#4657](https://github.com/ansible/molecule/pull/4657). The EC2 driver accessed the old attribute directly, causing inventory generation to fail with `AttributeError`. Reading the current attribute first and retaining the legacy fallback supports both APIs without changing user configuration.

## Testing
- `uvx pre-commit run --files src/molecule_plugins/ec2/driver.py test/ec2/test_driver.py`